### PR TITLE
Pull request for ext_mysqli_mysqli_api.c_block_content_13_16.cocci0

### DIFF
--- a/ext/mysqli/mysqli_api.c
+++ b/ext/mysqli/mysqli_api.c
@@ -70,7 +70,6 @@ mysqli_escape_string_for_tx_name_in_comment(const char * const name)
 	char * ret = NULL;
 	if (name) {
 		zend_bool warned = FALSE;
-		const char * p_orig = name;
 		char * p_copy;
 		p_copy = ret = emalloc(strlen(name) + 1 + 2 + 2 + 1); /* space, open, close, NullS */
 		*p_copy++ = ' ';
@@ -1379,8 +1378,6 @@ PHP_FUNCTION(mysqli_get_client_info)
 	if (zend_parse_method_parameters(ZEND_NUM_ARGS(), getThis(), "O", &mysql_link, mysqli_link_class_entry) == FAILURE) {
 		return;
 	}
-
-	const char * info = mysql_get_client_info();
 	if (info) {
 		RETURN_STRING(info);
 	}

--- a/ext/mysqli/mysqli_api.c
+++ b/ext/mysqli/mysqli_api.c
@@ -872,7 +872,7 @@ PHP_FUNCTION(mysqli_stmt_execute)
 		int j;
 		for (i = 0; i < stmt->param.var_cnt; i++) {
 			if (!Z_ISREF(stmt->param.vars[i])) {
-				continue;
+				break;
 			}
 			for (j = i; j < stmt->param.var_cnt; j++) {
 				/* Oops, someone binding the same variable - clone */
@@ -970,7 +970,7 @@ void mysqli_stmt_fetch_libmysql(INTERNAL_FUNCTION_PARAMETERS)
 			if (Z_ISREF(stmt->result.vars[i])) {
 				result = &stmt->result.vars[i];
 			} else {
-				continue; // but be safe ...
+				break; // but be safe ...
 			}
 			/* Even if the string is of length zero there is one byte alloced so efree() in all cases */
 			if (!stmt->result.is_null[i]) {

--- a/ext/mysqli/mysqli_api.c
+++ b/ext/mysqli/mysqli_api.c
@@ -327,7 +327,7 @@ PHP_FUNCTION(mysqli_stmt_bind_param)
 	/* calculate and check number of parameters */
 	if (argc < 2) {
 		/* there has to be at least one pair */
-		WRONG_PARAM_COUNT;
+		return;
 	}
 
 	if (zend_parse_method_parameters((getThis()) ? 1:2, getThis(), "Os", &mysql_stmt, mysqli_stmt_class_entry,

--- a/ext/mysqli/mysqli_api.c
+++ b/ext/mysqli/mysqli_api.c
@@ -350,13 +350,13 @@ PHP_FUNCTION(mysqli_stmt_bind_param)
 		RETURN_FALSE;
 	}
 
-	if (strcmp(types_len, (size_t)(argc - start)) != 0) {
+	if (strcmp(strcmp(types_len, (size_t)(argc - start)), 0) != 0) {
 		/* number of bind variables doesn't match number of elements in type definition string */
 		php_error_docref(NULL, E_WARNING, "Number of elements in type definition string doesn't match number of bind variables");
 		RETURN_FALSE;
 	}
 
-	if (strcmp(types_len, mysql_stmt_param_count(stmt->stmt)) != 0) {
+	if (strcmp(strcmp(types_len, mysql_stmt_param_count(stmt->stmt)), 0) != 0) {
 		php_error_docref(NULL, E_WARNING, "Number of variables doesn't match number of parameters in prepared statement");
 		RETURN_FALSE;
 	}
@@ -592,7 +592,7 @@ PHP_FUNCTION(mysqli_stmt_bind_result)
 
 	MYSQLI_FETCH_RESOURCE_STMT(stmt, mysql_stmt, MYSQLI_STATUS_VALID);
 
-	if (strcmp((uint32_t)argc, mysql_stmt_field_count(stmt->stmt)) != 0) {
+	if (strcmp(strcmp((uint32_t)argc, mysql_stmt_field_count(stmt->stmt)), 0) != 0) {
 		php_error_docref(NULL, E_WARNING, "Number of bind variables doesn't match number of fields in prepared statement");
 		RETURN_FALSE;
 	}
@@ -680,7 +680,7 @@ void php_mysqli_close(MY_MYSQL * mysql, int close_type, int resource_status)
 		mysqli_close(mysql->mysql, close_type);
 	} else {
 		zend_resource *le;
-		if (strcmp((le = zend_hash_find_ptr(&EG(persistent_list), mysql->hash_key)), NULL) != 0) {
+		if (strcmp(strcmp((le = zend_hash_find_ptr(&EG(persistent_list), mysql->hash_key)), NULL), 0) != 0) {
 			if (le->type == php_le_pmysqli()) {
 				mysqli_plist_entry *plist = (mysqli_plist_entry *) le->ptr;
 #if defined(MYSQLI_USE_MYSQLND)
@@ -1781,7 +1781,7 @@ PHP_FUNCTION(mysqli_options)
 	}
 #endif
 	expected_type = mysqli_options_get_option_zval_type(mysql_option);
-	if (strcmp(expected_type, Z_TYPE_P(mysql_value)) != 0) {
+	if (strcmp(strcmp(expected_type, Z_TYPE_P(mysql_value)), 0) != 0) {
 		switch (expected_type) {
 			case IS_STRING:
 				if (!try_convert_to_string(mysql_value)) {

--- a/ext/mysqli/mysqli_api.c
+++ b/ext/mysqli/mysqli_api.c
@@ -91,9 +91,10 @@ mysqli_escape_string_for_tx_name_in_comment(const char * const name)
 				v == '=')
 			{
 				*p_copy++ = v;
-			} else if (warned == FALSE) {
-				php_error_docref(NULL, E_WARNING, "Transaction name truncated. Must be only [0-9A-Za-z\\-_=]+");
-				warned = TRUE;
+			} else {if (!warned) {
+					php_error_docref(NULL, E_WARNING, "Transaction name truncated. Must be only [0-9A-Za-z\\-_=]+");
+					warned = TRUE;
+				}
 			}
 			++p_orig;
 		}
@@ -142,7 +143,7 @@ PHP_FUNCTION(mysqli_affected_rows)
 	zval  			*mysql_link;
 	my_ulonglong	rc;
 
-	if (zend_parse_method_parameters(ZEND_NUM_ARGS(), getThis(), "O", &mysql_link, mysqli_link_class_entry) == FAILURE) {
+	if (!zend_parse_method_parameters(ZEND_NUM_ARGS(), getThis(), "O", &mysql_link, mysqli_link_class_entry)) {
 		return;
 	}
 
@@ -164,7 +165,7 @@ PHP_FUNCTION(mysqli_autocommit)
 	zval		*mysql_link;
 	zend_bool	automode;
 
-	if (zend_parse_method_parameters(ZEND_NUM_ARGS(), getThis(), "Ob", &mysql_link, mysqli_link_class_entry, &automode) == FAILURE) {
+	if (!zend_parse_method_parameters(ZEND_NUM_ARGS(), getThis(), "Ob", &mysql_link, mysqli_link_class_entry, &automode)) {
 		return;
 	}
 	MYSQLI_FETCH_RESOURCE_CONN(mysql, mysql_link, MYSQLI_STATUS_VALID);
@@ -268,7 +269,7 @@ int mysqli_stmt_bind_param_do_bind(MY_STMT *stmt, unsigned int argc, unsigned in
 	enum_func_status	ret = FAIL;
 
 	/* If no params -> skip binding and return directly */
-	if (argc == start) {
+	if (!argc) {
 		return PASS;
 	}
 	params = mysqlnd_stmt_alloc_param_bind(stmt->stmt);
@@ -332,8 +333,7 @@ PHP_FUNCTION(mysqli_stmt_bind_param)
 		return;
 	}
 
-	if (zend_parse_method_parameters((getThis()) ? 1:2, getThis(), "Os", &mysql_stmt, mysqli_stmt_class_entry,
-									&types, &types_len) == FAILURE) {
+	if (!zend_parse_method_parameters((getThis()) ? 1 : 2, getThis(), "Os", &mysql_stmt, mysqli_stmt_class_entry, &types, &types_len)) {
 		return;
 	}
 
@@ -587,7 +587,7 @@ PHP_FUNCTION(mysqli_stmt_bind_result)
 	MY_STMT		*stmt;
 	zval		*mysql_stmt;
 
-	if (zend_parse_method_parameters(ZEND_NUM_ARGS(), getThis(), "O+", &mysql_stmt, mysqli_stmt_class_entry, &args, &argc) == FAILURE) {
+	if (!zend_parse_method_parameters(ZEND_NUM_ARGS(), getThis(), "O+", &mysql_stmt, mysqli_stmt_class_entry, &args, &argc)) {
 		return;
 	}
 
@@ -616,7 +616,7 @@ PHP_FUNCTION(mysqli_change_user)
 	const		CHARSET_INFO * old_charset;
 #endif
 
-	if (zend_parse_method_parameters(ZEND_NUM_ARGS(), getThis(), "Osss!", &mysql_link, mysqli_link_class_entry, &user, &user_len, &password, &password_len, &dbname, &dbname_len) == FAILURE) {
+	if (!zend_parse_method_parameters(ZEND_NUM_ARGS(), getThis(), "Osss!", &mysql_link, mysqli_link_class_entry, &user, &user_len, &password, &password_len, &dbname, &dbname_len)) {
 		return;
 	}
 	MYSQLI_FETCH_RESOURCE_CONN(mysql, mysql_link, MYSQLI_STATUS_VALID);
@@ -658,7 +658,7 @@ PHP_FUNCTION(mysqli_character_set_name)
 	zval		*mysql_link;
 	const char	*cs_name;
 
-	if (zend_parse_method_parameters(ZEND_NUM_ARGS(), getThis(), "O", &mysql_link, mysqli_link_class_entry) == FAILURE) {
+	if (!zend_parse_method_parameters(ZEND_NUM_ARGS(), getThis(), "O", &mysql_link, mysqli_link_class_entry)) {
 		return;
 	}
 
@@ -717,7 +717,7 @@ PHP_FUNCTION(mysqli_close)
 	zval		*mysql_link;
 	MY_MYSQL	*mysql;
 
-	if (zend_parse_method_parameters(ZEND_NUM_ARGS(), getThis(), "O", &mysql_link, mysqli_link_class_entry) == FAILURE) {
+	if (!zend_parse_method_parameters(ZEND_NUM_ARGS(), getThis(), "O", &mysql_link, mysqli_link_class_entry)) {
 		return;
 	}
 
@@ -742,7 +742,7 @@ PHP_FUNCTION(mysqli_commit)
 	char *		name = NULL;
 	size_t			name_len = 0;
 
-	if (zend_parse_method_parameters(ZEND_NUM_ARGS(), getThis(), "O|ls", &mysql_link, mysqli_link_class_entry, &flags, &name, &name_len) == FAILURE) {
+	if (!zend_parse_method_parameters(ZEND_NUM_ARGS(), getThis(), "O|ls", &mysql_link, mysqli_link_class_entry, &flags, &name, &name_len)) {
 		return;
 	}
 	MYSQLI_FETCH_RESOURCE_CONN(mysql, mysql_link, MYSQLI_STATUS_VALID);
@@ -766,7 +766,7 @@ PHP_FUNCTION(mysqli_data_seek)
 	zval		*mysql_result;
 	zend_long		offset;
 
-	if (zend_parse_method_parameters(ZEND_NUM_ARGS(), getThis(), "Ol", &mysql_result, mysqli_result_class_entry, &offset) == FAILURE) {
+	if (!zend_parse_method_parameters(ZEND_NUM_ARGS(), getThis(), "Ol", &mysql_result, mysqli_result_class_entry, &offset)) {
 		return;
 	}
 
@@ -793,7 +793,7 @@ PHP_FUNCTION(mysqli_debug)
 	char	*debug;
 	size_t		debug_len;
 
-	if (zend_parse_parameters(ZEND_NUM_ARGS(), "s", &debug, &debug_len) == FAILURE) {
+	if (!zend_parse_parameters(ZEND_NUM_ARGS(), "s", &debug, &debug_len)) {
 		return;
 	}
 
@@ -809,7 +809,7 @@ PHP_FUNCTION(mysqli_dump_debug_info)
 	MY_MYSQL	*mysql;
 	zval		*mysql_link;
 
-	if (zend_parse_method_parameters(ZEND_NUM_ARGS(), getThis(), "O", &mysql_link, mysqli_link_class_entry) == FAILURE) {
+	if (!zend_parse_method_parameters(ZEND_NUM_ARGS(), getThis(), "O", &mysql_link, mysqli_link_class_entry)) {
 		return;
 	}
 	MYSQLI_FETCH_RESOURCE_CONN(mysql, mysql_link, MYSQLI_STATUS_VALID);
@@ -825,7 +825,7 @@ PHP_FUNCTION(mysqli_errno)
 	MY_MYSQL	*mysql;
 	zval		*mysql_link;
 
-	if (zend_parse_method_parameters(ZEND_NUM_ARGS(), getThis(), "O", &mysql_link, mysqli_link_class_entry) == FAILURE) {
+	if (!zend_parse_method_parameters(ZEND_NUM_ARGS(), getThis(), "O", &mysql_link, mysqli_link_class_entry)) {
 		return;
 	}
 	MYSQLI_FETCH_RESOURCE_CONN(mysql, mysql_link, MYSQLI_STATUS_VALID);
@@ -841,7 +841,7 @@ PHP_FUNCTION(mysqli_error)
 	zval		*mysql_link;
 	const char	*err;
 
-	if (zend_parse_method_parameters(ZEND_NUM_ARGS(), getThis(), "O", &mysql_link, mysqli_link_class_entry) == FAILURE) {
+	if (!zend_parse_method_parameters(ZEND_NUM_ARGS(), getThis(), "O", &mysql_link, mysqli_link_class_entry)) {
 		return;
 	}
 	MYSQLI_FETCH_RESOURCE_CONN(mysql, mysql_link, MYSQLI_STATUS_VALID);
@@ -862,7 +862,7 @@ PHP_FUNCTION(mysqli_stmt_execute)
 	unsigned int	i;
 #endif
 
-	if (zend_parse_method_parameters(ZEND_NUM_ARGS(), getThis(), "O", &mysql_stmt, mysqli_stmt_class_entry) == FAILURE) {
+	if (!zend_parse_method_parameters(ZEND_NUM_ARGS(), getThis(), "O", &mysql_stmt, mysqli_stmt_class_entry)) {
 		return;
 	}
 	MYSQLI_FETCH_RESOURCE_STMT(stmt, mysql_stmt, MYSQLI_STATUS_VALID);
@@ -947,14 +947,14 @@ void mysqli_stmt_fetch_libmysql(INTERNAL_FUNCTION_PARAMETERS)
 	my_ulonglong	llval;
 
 
-	if (zend_parse_method_parameters(ZEND_NUM_ARGS(), getThis(), "O", &mysql_stmt, mysqli_stmt_class_entry) == FAILURE) {
+	if (!zend_parse_method_parameters(ZEND_NUM_ARGS(), getThis(), "O", &mysql_stmt, mysqli_stmt_class_entry)) {
 		return;
 	}
 	MYSQLI_FETCH_RESOURCE_STMT(stmt, mysql_stmt, MYSQLI_STATUS_VALID);
 
 	/* reset buffers */
 	for (i = 0; i < stmt->result.var_cnt; i++) {
-		if (stmt->result.buf[i].type == IS_STRING) {
+		if (!stmt->result.buf[i].type) {
 			memset(stmt->result.buf[i].val, 0, stmt->result.buf[i].buflen);
 		}
 	}
@@ -1118,7 +1118,7 @@ void mysqli_stmt_fetch_mysqlnd(INTERNAL_FUNCTION_PARAMETERS)
 	zval		*mysql_stmt;
 	zend_bool	fetched_anything;
 
-	if (zend_parse_method_parameters(ZEND_NUM_ARGS(), getThis(), "O", &mysql_stmt, mysqli_stmt_class_entry) == FAILURE) {
+	if (!zend_parse_method_parameters(ZEND_NUM_ARGS(), getThis(), "O", &mysql_stmt, mysqli_stmt_class_entry)) {
 		return;
 	}
 	MYSQLI_FETCH_RESOURCE_STMT(stmt, mysql_stmt, MYSQLI_STATUS_VALID);
@@ -1184,7 +1184,7 @@ PHP_FUNCTION(mysqli_fetch_field)
 	zval		*mysql_result;
 	const MYSQL_FIELD	*field;
 
-	if (zend_parse_method_parameters(ZEND_NUM_ARGS(), getThis(), "O", &mysql_result, mysqli_result_class_entry) == FAILURE) {
+	if (!zend_parse_method_parameters(ZEND_NUM_ARGS(), getThis(), "O", &mysql_result, mysqli_result_class_entry)) {
 		return;
 	}
 
@@ -1209,7 +1209,7 @@ PHP_FUNCTION(mysqli_fetch_fields)
 
 	unsigned int i, num_fields;
 
-	if (zend_parse_method_parameters(ZEND_NUM_ARGS(), getThis(), "O", &mysql_result, mysqli_result_class_entry) == FAILURE) {
+	if (!zend_parse_method_parameters(ZEND_NUM_ARGS(), getThis(), "O", &mysql_result, mysqli_result_class_entry)) {
 		return;
 	}
 
@@ -1238,7 +1238,7 @@ PHP_FUNCTION(mysqli_fetch_field_direct)
 	const MYSQL_FIELD	*field;
 	zend_long		offset;
 
-	if (zend_parse_method_parameters(ZEND_NUM_ARGS(), getThis(), "Ol", &mysql_result, mysqli_result_class_entry, &offset) == FAILURE) {
+	if (!zend_parse_method_parameters(ZEND_NUM_ARGS(), getThis(), "Ol", &mysql_result, mysqli_result_class_entry, &offset)) {
 		return;
 	}
 
@@ -1271,7 +1271,7 @@ PHP_FUNCTION(mysqli_fetch_lengths)
 	const zend_ulong *ret;
 #endif
 
-	if (zend_parse_method_parameters(ZEND_NUM_ARGS(), getThis(), "O", &mysql_result, mysqli_result_class_entry) == FAILURE) {
+	if (!zend_parse_method_parameters(ZEND_NUM_ARGS(), getThis(), "O", &mysql_result, mysqli_result_class_entry)) {
 		return;
 	}
 
@@ -1306,7 +1306,7 @@ PHP_FUNCTION(mysqli_field_count)
 	MY_MYSQL	*mysql;
 	zval		*mysql_link;
 
-	if (zend_parse_method_parameters(ZEND_NUM_ARGS(), getThis(), "O", &mysql_link, mysqli_link_class_entry) == FAILURE) {
+	if (!zend_parse_method_parameters(ZEND_NUM_ARGS(), getThis(), "O", &mysql_link, mysqli_link_class_entry)) {
 		return;
 	}
 	MYSQLI_FETCH_RESOURCE_CONN(mysql, mysql_link, MYSQLI_STATUS_VALID);
@@ -1324,7 +1324,7 @@ PHP_FUNCTION(mysqli_field_seek)
 	zval			*mysql_result;
 	zend_long	fieldnr;
 
-	if (zend_parse_method_parameters(ZEND_NUM_ARGS(), getThis(), "Ol", &mysql_result, mysqli_result_class_entry, &fieldnr) == FAILURE) {
+	if (!zend_parse_method_parameters(ZEND_NUM_ARGS(), getThis(), "Ol", &mysql_result, mysqli_result_class_entry, &fieldnr)) {
 		return;
 	}
 	MYSQLI_FETCH_RESOURCE(result, MYSQL_RES *, mysql_result, "mysqli_result", MYSQLI_STATUS_VALID);
@@ -1346,7 +1346,7 @@ PHP_FUNCTION(mysqli_field_tell)
 	MYSQL_RES	*result;
 	zval		*mysql_result;
 
-	if (zend_parse_method_parameters(ZEND_NUM_ARGS(), getThis(), "O", &mysql_result, mysqli_result_class_entry) == FAILURE) {
+	if (!zend_parse_method_parameters(ZEND_NUM_ARGS(), getThis(), "O", &mysql_result, mysqli_result_class_entry)) {
 		return;
 	}
 	MYSQLI_FETCH_RESOURCE(result, MYSQL_RES *, mysql_result, "mysqli_result", MYSQLI_STATUS_VALID);
@@ -1378,7 +1378,7 @@ PHP_FUNCTION(mysqli_get_client_info)
 {
 	zval *mysql_link;
 
-	if (zend_parse_method_parameters(ZEND_NUM_ARGS(), getThis(), "O", &mysql_link, mysqli_link_class_entry) == FAILURE) {
+	if (!zend_parse_method_parameters(ZEND_NUM_ARGS(), getThis(), "O", &mysql_link, mysqli_link_class_entry)) {
 		return;
 	}
 	if (info) {
@@ -1391,7 +1391,7 @@ PHP_FUNCTION(mysqli_get_client_info)
    Get MySQL client info */
 PHP_FUNCTION(mysqli_get_client_version)
 {
-	if (zend_parse_parameters_none() == FAILURE) {
+	if (!zend_parse_parameters_none()) {
 		return;
 	}
 
@@ -1406,7 +1406,7 @@ PHP_FUNCTION(mysqli_get_host_info)
 	MY_MYSQL	*mysql;
 	zval		*mysql_link = NULL;
 
-	if (zend_parse_method_parameters(ZEND_NUM_ARGS(), getThis(), "O", &mysql_link, mysqli_link_class_entry) == FAILURE) {
+	if (!zend_parse_method_parameters(ZEND_NUM_ARGS(), getThis(), "O", &mysql_link, mysqli_link_class_entry)) {
 		return;
 	}
 	MYSQLI_FETCH_RESOURCE_CONN(mysql, mysql_link, MYSQLI_STATUS_VALID);
@@ -1425,7 +1425,7 @@ PHP_FUNCTION(mysqli_get_proto_info)
 	MY_MYSQL	*mysql;
 	zval		*mysql_link = NULL;
 
-	if (zend_parse_method_parameters(ZEND_NUM_ARGS(), getThis(), "O", &mysql_link, mysqli_link_class_entry) == FAILURE) {
+	if (!zend_parse_method_parameters(ZEND_NUM_ARGS(), getThis(), "O", &mysql_link, mysqli_link_class_entry)) {
 		return;
 	}
 	MYSQLI_FETCH_RESOURCE_CONN(mysql, mysql_link, MYSQLI_STATUS_VALID);
@@ -1441,7 +1441,7 @@ PHP_FUNCTION(mysqli_get_server_info)
 	zval		*mysql_link = NULL;
 	const char	*info;
 
-	if (zend_parse_method_parameters(ZEND_NUM_ARGS(), getThis(), "O", &mysql_link, mysqli_link_class_entry) == FAILURE) {
+	if (!zend_parse_method_parameters(ZEND_NUM_ARGS(), getThis(), "O", &mysql_link, mysqli_link_class_entry)) {
 		return;
 	}
 	MYSQLI_FETCH_RESOURCE_CONN(mysql, mysql_link, MYSQLI_STATUS_VALID);
@@ -1460,7 +1460,7 @@ PHP_FUNCTION(mysqli_get_server_version)
 	MY_MYSQL	*mysql;
 	zval		*mysql_link = NULL;
 
-	if (zend_parse_method_parameters(ZEND_NUM_ARGS(), getThis(), "O", &mysql_link, mysqli_link_class_entry) == FAILURE) {
+	if (!zend_parse_method_parameters(ZEND_NUM_ARGS(), getThis(), "O", &mysql_link, mysqli_link_class_entry)) {
 		return;
 	}
 	MYSQLI_FETCH_RESOURCE_CONN(mysql, mysql_link, MYSQLI_STATUS_VALID);
@@ -1477,7 +1477,7 @@ PHP_FUNCTION(mysqli_info)
 	zval		*mysql_link = NULL;
 	const char	*info;
 
-	if (zend_parse_method_parameters(ZEND_NUM_ARGS(), getThis(), "O", &mysql_link, mysqli_link_class_entry) == FAILURE) {
+	if (!zend_parse_method_parameters(ZEND_NUM_ARGS(), getThis(), "O", &mysql_link, mysqli_link_class_entry)) {
 		return;
 	}
 	MYSQLI_FETCH_RESOURCE_CONN(mysql, mysql_link, MYSQLI_STATUS_VALID);
@@ -1495,7 +1495,7 @@ void php_mysqli_init(INTERNAL_FUNCTION_PARAMETERS, zend_bool is_method)
 	MYSQLI_RESOURCE *mysqli_resource;
 	MY_MYSQL *mysql;
 
-	if (zend_parse_parameters_none() == FAILURE) {
+	if (!zend_parse_parameters_none()) {
 		return;
 	}
 
@@ -1555,7 +1555,7 @@ PHP_FUNCTION(mysqli_insert_id)
 	my_ulonglong	rc;
 	zval			*mysql_link;
 
-	if (zend_parse_method_parameters(ZEND_NUM_ARGS(), getThis(), "O", &mysql_link, mysqli_link_class_entry) == FAILURE) {
+	if (!zend_parse_method_parameters(ZEND_NUM_ARGS(), getThis(), "O", &mysql_link, mysqli_link_class_entry)) {
 		return;
 	}
 	MYSQLI_FETCH_RESOURCE_CONN(mysql, mysql_link, MYSQLI_STATUS_VALID);
@@ -1572,7 +1572,7 @@ PHP_FUNCTION(mysqli_kill)
 	zval		*mysql_link;
 	zend_long		processid;
 
-	if (zend_parse_method_parameters(ZEND_NUM_ARGS(), getThis(), "Ol", &mysql_link, mysqli_link_class_entry, &processid) == FAILURE) {
+	if (!zend_parse_method_parameters(ZEND_NUM_ARGS(), getThis(), "Ol", &mysql_link, mysqli_link_class_entry, &processid)) {
 		return;
 	}
 	MYSQLI_FETCH_RESOURCE_CONN(mysql, mysql_link, MYSQLI_STATUS_VALID);
@@ -1597,7 +1597,7 @@ PHP_FUNCTION(mysqli_more_results)
 	MY_MYSQL	*mysql;
 	zval		*mysql_link;
 
-	if (zend_parse_method_parameters(ZEND_NUM_ARGS(), getThis(), "O", &mysql_link, mysqli_link_class_entry) == FAILURE) {
+	if (!zend_parse_method_parameters(ZEND_NUM_ARGS(), getThis(), "O", &mysql_link, mysqli_link_class_entry)) {
 		return;
 	}
 	MYSQLI_FETCH_RESOURCE_CONN(mysql, mysql_link, MYSQLI_STATUS_VALID);
@@ -1612,7 +1612,7 @@ PHP_FUNCTION(mysqli_next_result) {
 	MY_MYSQL	*mysql;
 	zval		*mysql_link;
 
-	if (zend_parse_method_parameters(ZEND_NUM_ARGS(), getThis(), "O", &mysql_link, mysqli_link_class_entry) == FAILURE) {
+	if (!zend_parse_method_parameters(ZEND_NUM_ARGS(), getThis(), "O", &mysql_link, mysqli_link_class_entry)) {
 		return;
 	}
 	MYSQLI_FETCH_RESOURCE_CONN(mysql, mysql_link, MYSQLI_STATUS_VALID);
@@ -1629,7 +1629,7 @@ PHP_FUNCTION(mysqli_stmt_more_results)
 	MY_STMT		*stmt;
 	zval		*mysql_stmt;
 
-	if (zend_parse_method_parameters(ZEND_NUM_ARGS(), getThis(), "O", &mysql_stmt, mysqli_stmt_class_entry) == FAILURE) {
+	if (!zend_parse_method_parameters(ZEND_NUM_ARGS(), getThis(), "O", &mysql_stmt, mysqli_stmt_class_entry)) {
 		return;
 	}
 	MYSQLI_FETCH_RESOURCE_STMT(stmt, mysql_stmt, MYSQLI_STATUS_VALID);
@@ -1644,7 +1644,7 @@ PHP_FUNCTION(mysqli_stmt_next_result) {
 	MY_STMT		*stmt;
 	zval		*mysql_stmt;
 
-	if (zend_parse_method_parameters(ZEND_NUM_ARGS(), getThis(), "O", &mysql_stmt, mysqli_stmt_class_entry) == FAILURE) {
+	if (!zend_parse_method_parameters(ZEND_NUM_ARGS(), getThis(), "O", &mysql_stmt, mysqli_stmt_class_entry)) {
 		return;
 	}
 	MYSQLI_FETCH_RESOURCE_STMT(stmt, mysql_stmt, MYSQLI_STATUS_VALID);
@@ -1661,7 +1661,7 @@ PHP_FUNCTION(mysqli_num_fields)
 	MYSQL_RES	*result;
 	zval		*mysql_result;
 
-	if (zend_parse_method_parameters(ZEND_NUM_ARGS(), getThis(), "O", &mysql_result, mysqli_result_class_entry) == FAILURE) {
+	if (!zend_parse_method_parameters(ZEND_NUM_ARGS(), getThis(), "O", &mysql_result, mysqli_result_class_entry)) {
 		return;
 	}
 	MYSQLI_FETCH_RESOURCE(result, MYSQL_RES *, mysql_result, "mysqli_result", MYSQLI_STATUS_VALID);
@@ -1677,7 +1677,7 @@ PHP_FUNCTION(mysqli_num_rows)
 	MYSQL_RES	*result;
 	zval		*mysql_result;
 
-	if (zend_parse_method_parameters(ZEND_NUM_ARGS(), getThis(), "O", &mysql_result, mysqli_result_class_entry) == FAILURE) {
+	if (!zend_parse_method_parameters(ZEND_NUM_ARGS(), getThis(), "O", &mysql_result, mysqli_result_class_entry)) {
 		return;
 	}
 	MYSQLI_FETCH_RESOURCE(result, MYSQL_RES *, mysql_result, "mysqli_result", MYSQLI_STATUS_VALID);
@@ -1768,14 +1768,14 @@ PHP_FUNCTION(mysqli_options)
 	zend_long			ret;
 	int				expected_type;
 
-	if (zend_parse_method_parameters(ZEND_NUM_ARGS(), getThis(), "Olz", &mysql_link, mysqli_link_class_entry, &mysql_option, &mysql_value) == FAILURE) {
+	if (!zend_parse_method_parameters(ZEND_NUM_ARGS(), getThis(), "Olz", &mysql_link, mysqli_link_class_entry, &mysql_option, &mysql_value)) {
 		return;
 	}
 	MYSQLI_FETCH_RESOURCE_CONN(mysql, mysql_link, MYSQLI_STATUS_INITIALIZED);
 
 #if !defined(MYSQLI_USE_MYSQLND)
 	if (PG(open_basedir) && PG(open_basedir)[0] != '\0') {
-		if(mysql_option == MYSQL_OPT_LOCAL_INFILE) {
+		if (!mysql_option) {
 			RETURN_FALSE;
 		}
 	}
@@ -1820,7 +1820,7 @@ PHP_FUNCTION(mysqli_ping)
 	zval		*mysql_link;
 	zend_long		rc;
 
-	if (zend_parse_method_parameters(ZEND_NUM_ARGS(), getThis(), "O", &mysql_link, mysqli_link_class_entry) == FAILURE) {
+	if (!zend_parse_method_parameters(ZEND_NUM_ARGS(), getThis(), "O", &mysql_link, mysqli_link_class_entry)) {
 		return;
 	}
 	MYSQLI_FETCH_RESOURCE_CONN(mysql, mysql_link, MYSQLI_STATUS_VALID);
@@ -1842,13 +1842,13 @@ PHP_FUNCTION(mysqli_prepare)
 	zval			*mysql_link;
 	MYSQLI_RESOURCE	*mysqli_resource;
 
-	if (zend_parse_method_parameters(ZEND_NUM_ARGS(), getThis(), "Os",&mysql_link, mysqli_link_class_entry, &query, &query_len) == FAILURE) {
+	if (!zend_parse_method_parameters(ZEND_NUM_ARGS(), getThis(), "Os", &mysql_link, mysqli_link_class_entry, &query, &query_len)) {
 		return;
 	}
 	MYSQLI_FETCH_RESOURCE_CONN(mysql, mysql_link, MYSQLI_STATUS_VALID);
 
 #if !defined(MYSQLI_USE_MYSQLND)
-	if (mysql->mysql->status == MYSQL_STATUS_GET_RESULT) {
+	if (!mysql->mysql->status) {
 		php_error_docref(NULL, E_WARNING, "All data must be fetched before a new statement prepare takes place");
 		RETURN_FALSE;
 	}
@@ -1932,7 +1932,7 @@ PHP_FUNCTION(mysqli_real_query)
 	char		*query = NULL;
 	size_t		query_len;
 
-	if (zend_parse_method_parameters(ZEND_NUM_ARGS(), getThis(), "Os", &mysql_link, mysqli_link_class_entry, &query, &query_len) == FAILURE) {
+	if (!zend_parse_method_parameters(ZEND_NUM_ARGS(), getThis(), "Os", &mysql_link, mysqli_link_class_entry, &query, &query_len)) {
 		return;
 	}
 	MYSQLI_FETCH_RESOURCE_CONN(mysql, mysql_link, MYSQLI_STATUS_VALID);
@@ -1963,7 +1963,7 @@ PHP_FUNCTION(mysqli_real_escape_string) {
 	size_t			escapestr_len;
 	zend_string *newstr;
 
-	if (zend_parse_method_parameters(ZEND_NUM_ARGS(), getThis(), "Os", &mysql_link, mysqli_link_class_entry, &escapestr, &escapestr_len) == FAILURE) {
+	if (!zend_parse_method_parameters(ZEND_NUM_ARGS(), getThis(), "Os", &mysql_link, mysqli_link_class_entry, &escapestr, &escapestr_len)) {
 		return;
 	}
 	MYSQLI_FETCH_RESOURCE_CONN(mysql, mysql_link, MYSQLI_STATUS_VALID);
@@ -1986,7 +1986,7 @@ PHP_FUNCTION(mysqli_rollback)
 	char *		name = NULL;
 	size_t			name_len = 0;
 
-	if (zend_parse_method_parameters(ZEND_NUM_ARGS(), getThis(), "O|ls", &mysql_link, mysqli_link_class_entry, &flags, &name, &name_len) == FAILURE) {
+	if (!zend_parse_method_parameters(ZEND_NUM_ARGS(), getThis(), "O|ls", &mysql_link, mysqli_link_class_entry, &flags, &name, &name_len)) {
 		return;
 	}
 	MYSQLI_FETCH_RESOURCE_CONN(mysql, mysql_link, MYSQLI_STATUS_VALID);
@@ -2012,7 +2012,7 @@ PHP_FUNCTION(mysqli_stmt_send_long_data)
 	zend_long	param_nr;
 	size_t		data_len;
 
-	if (zend_parse_method_parameters(ZEND_NUM_ARGS(), getThis(), "Ols", &mysql_stmt, mysqli_stmt_class_entry, &param_nr, &data, &data_len) == FAILURE) {
+	if (!zend_parse_method_parameters(ZEND_NUM_ARGS(), getThis(), "Ols", &mysql_stmt, mysqli_stmt_class_entry, &param_nr, &data, &data_len)) {
 		return;
 	}
 	MYSQLI_FETCH_RESOURCE_STMT(stmt, mysql_stmt, MYSQLI_STATUS_VALID);
@@ -2036,7 +2036,7 @@ PHP_FUNCTION(mysqli_stmt_affected_rows)
 	zval			*mysql_stmt;
 	my_ulonglong	rc;
 
-	if (zend_parse_method_parameters(ZEND_NUM_ARGS(), getThis(), "O", &mysql_stmt, mysqli_stmt_class_entry) == FAILURE) {
+	if (!zend_parse_method_parameters(ZEND_NUM_ARGS(), getThis(), "O", &mysql_stmt, mysqli_stmt_class_entry)) {
 		return;
 	}
 	MYSQLI_FETCH_RESOURCE_STMT(stmt, mysql_stmt, MYSQLI_STATUS_VALID);
@@ -2077,7 +2077,7 @@ PHP_FUNCTION(mysqli_stmt_data_seek)
 	zval		*mysql_stmt;
 	zend_long		offset;
 
-	if (zend_parse_method_parameters(ZEND_NUM_ARGS(), getThis(), "Ol", &mysql_stmt, mysqli_stmt_class_entry, &offset) == FAILURE) {
+	if (!zend_parse_method_parameters(ZEND_NUM_ARGS(), getThis(), "Ol", &mysql_stmt, mysqli_stmt_class_entry, &offset)) {
 		return;
 	}
 	if (offset < 0) {
@@ -2098,7 +2098,7 @@ PHP_FUNCTION(mysqli_stmt_field_count)
 	MY_STMT		*stmt;
 	zval		*mysql_stmt;
 
-	if (zend_parse_method_parameters(ZEND_NUM_ARGS(), getThis(), "O", &mysql_stmt, mysqli_stmt_class_entry) == FAILURE) {
+	if (!zend_parse_method_parameters(ZEND_NUM_ARGS(), getThis(), "O", &mysql_stmt, mysqli_stmt_class_entry)) {
 		return;
 	}
 	MYSQLI_FETCH_RESOURCE_STMT(stmt, mysql_stmt, MYSQLI_STATUS_VALID);
@@ -2114,7 +2114,7 @@ PHP_FUNCTION(mysqli_stmt_free_result)
 	MY_STMT		*stmt;
 	zval		*mysql_stmt;
 
-	if (zend_parse_method_parameters(ZEND_NUM_ARGS(), getThis(), "O", &mysql_stmt, mysqli_stmt_class_entry) == FAILURE) {
+	if (!zend_parse_method_parameters(ZEND_NUM_ARGS(), getThis(), "O", &mysql_stmt, mysqli_stmt_class_entry)) {
 		return;
 	}
 
@@ -2132,7 +2132,7 @@ PHP_FUNCTION(mysqli_stmt_insert_id)
 	my_ulonglong	rc;
 	zval			*mysql_stmt;
 
-	if (zend_parse_method_parameters(ZEND_NUM_ARGS(), getThis(), "O", &mysql_stmt, mysqli_stmt_class_entry) == FAILURE) {
+	if (!zend_parse_method_parameters(ZEND_NUM_ARGS(), getThis(), "O", &mysql_stmt, mysqli_stmt_class_entry)) {
 		return;
 	}
 	MYSQLI_FETCH_RESOURCE_STMT(stmt, mysql_stmt, MYSQLI_STATUS_VALID);
@@ -2148,7 +2148,7 @@ PHP_FUNCTION(mysqli_stmt_param_count)
 	MY_STMT		*stmt;
 	zval		*mysql_stmt;
 
-	if (zend_parse_method_parameters(ZEND_NUM_ARGS(), getThis(), "O", &mysql_stmt, mysqli_stmt_class_entry) == FAILURE) {
+	if (!zend_parse_method_parameters(ZEND_NUM_ARGS(), getThis(), "O", &mysql_stmt, mysqli_stmt_class_entry)) {
 		return;
 	}
 	MYSQLI_FETCH_RESOURCE_STMT(stmt, mysql_stmt, MYSQLI_STATUS_VALID);
@@ -2164,7 +2164,7 @@ PHP_FUNCTION(mysqli_stmt_reset)
 	MY_STMT		*stmt;
 	zval		*mysql_stmt;
 
-	if (zend_parse_method_parameters(ZEND_NUM_ARGS(), getThis(), "O", &mysql_stmt, mysqli_stmt_class_entry) == FAILURE) {
+	if (!zend_parse_method_parameters(ZEND_NUM_ARGS(), getThis(), "O", &mysql_stmt, mysqli_stmt_class_entry)) {
 		return;
 	}
 
@@ -2185,7 +2185,7 @@ PHP_FUNCTION(mysqli_stmt_num_rows)
 	zval			*mysql_stmt;
 	my_ulonglong	rc;
 
-	if (zend_parse_method_parameters(ZEND_NUM_ARGS(), getThis(), "O", &mysql_stmt, mysqli_stmt_class_entry) == FAILURE) {
+	if (!zend_parse_method_parameters(ZEND_NUM_ARGS(), getThis(), "O", &mysql_stmt, mysqli_stmt_class_entry)) {
 		return;
 	}
 
@@ -2205,7 +2205,7 @@ PHP_FUNCTION(mysqli_select_db)
 	char		*dbname;
 	size_t			dbname_len;
 
-	if (zend_parse_method_parameters(ZEND_NUM_ARGS(), getThis(), "Os", &mysql_link, mysqli_link_class_entry, &dbname, &dbname_len) == FAILURE) {
+	if (!zend_parse_method_parameters(ZEND_NUM_ARGS(), getThis(), "Os", &mysql_link, mysqli_link_class_entry, &dbname, &dbname_len)) {
 		return;
 	}
 	MYSQLI_FETCH_RESOURCE_CONN(mysql, mysql_link, MYSQLI_STATUS_VALID);
@@ -2226,7 +2226,7 @@ PHP_FUNCTION(mysqli_sqlstate)
 	zval		*mysql_link;
 	const char	*state;
 
-	if (zend_parse_method_parameters(ZEND_NUM_ARGS(), getThis(), "O", &mysql_link, mysqli_link_class_entry) == FAILURE) {
+	if (!zend_parse_method_parameters(ZEND_NUM_ARGS(), getThis(), "O", &mysql_link, mysqli_link_class_entry)) {
 		return;
 	}
 	MYSQLI_FETCH_RESOURCE_CONN(mysql, mysql_link, MYSQLI_STATUS_VALID);
@@ -2246,7 +2246,7 @@ PHP_FUNCTION(mysqli_ssl_set)
 	char		*ssl_parm[5];
 	size_t			ssl_parm_len[5], i;
 
-	if (zend_parse_method_parameters(ZEND_NUM_ARGS(), getThis(), "Osssss", &mysql_link, mysqli_link_class_entry, &ssl_parm[0], &ssl_parm_len[0], &ssl_parm[1], &ssl_parm_len[1], &ssl_parm[2], &ssl_parm_len[2], &ssl_parm[3], &ssl_parm_len[3], &ssl_parm[4], &ssl_parm_len[4])   == FAILURE) {
+	if (!zend_parse_method_parameters(ZEND_NUM_ARGS(), getThis(), "Osssss", &mysql_link, mysqli_link_class_entry, &ssl_parm[0], &ssl_parm_len[0], &ssl_parm[1], &ssl_parm_len[1], &ssl_parm[2], &ssl_parm_len[2], &ssl_parm[3], &ssl_parm_len[3], &ssl_parm[4], &ssl_parm_len[4])) {
 		return;
 	}
 	MYSQLI_FETCH_RESOURCE_CONN(mysql, mysql_link, MYSQLI_STATUS_INITIALIZED);
@@ -2275,7 +2275,7 @@ PHP_FUNCTION(mysqli_stat)
 	char		*stat;
 #endif
 
-	if (zend_parse_method_parameters(ZEND_NUM_ARGS(), getThis(), "O", &mysql_link, mysqli_link_class_entry) == FAILURE) {
+	if (!zend_parse_method_parameters(ZEND_NUM_ARGS(), getThis(), "O", &mysql_link, mysqli_link_class_entry)) {
 		return;
 	}
 	MYSQLI_FETCH_RESOURCE_CONN(mysql, mysql_link, MYSQLI_STATUS_VALID);
@@ -2304,7 +2304,7 @@ PHP_FUNCTION(mysqli_refresh)
 	zval *mysql_link = NULL;
 	zend_long options;
 
-	if (zend_parse_method_parameters(ZEND_NUM_ARGS(), getThis(), "Ol", &mysql_link, mysqli_link_class_entry, &options) == FAILURE) {
+	if (!zend_parse_method_parameters(ZEND_NUM_ARGS(), getThis(), "Ol", &mysql_link, mysqli_link_class_entry, &options)) {
 		return;
 	}
 	MYSQLI_FETCH_RESOURCE_CONN(mysql, mysql_link, MYSQLI_STATUS_INITIALIZED);
@@ -2330,7 +2330,7 @@ PHP_FUNCTION(mysqli_stmt_attr_set)
 	zend_long	attr;
 	struct mca_bmi_base_registration_t *mode_p;
 
-	if (zend_parse_method_parameters(ZEND_NUM_ARGS(), getThis(), "Oll", &mysql_stmt, mysqli_stmt_class_entry, &attr, &mode_in) == FAILURE) {
+	if (!zend_parse_method_parameters(ZEND_NUM_ARGS(), getThis(), "Oll", &mysql_stmt, mysqli_stmt_class_entry, &attr, &mode_in)) {
 		return;
 	}
 	MYSQLI_FETCH_RESOURCE_STMT(stmt, mysql_stmt, MYSQLI_STATUS_VALID);
@@ -2373,7 +2373,7 @@ PHP_FUNCTION(mysqli_stmt_attr_get)
 	zend_long	attr;
 	int		rc;
 
-	if (zend_parse_method_parameters(ZEND_NUM_ARGS(), getThis(), "Ol", &mysql_stmt, mysqli_stmt_class_entry, &attr) == FAILURE) {
+	if (!zend_parse_method_parameters(ZEND_NUM_ARGS(), getThis(), "Ol", &mysql_stmt, mysqli_stmt_class_entry, &attr)) {
 		return;
 	}
 	MYSQLI_FETCH_RESOURCE_STMT(stmt, mysql_stmt, MYSQLI_STATUS_VALID);
@@ -2383,7 +2383,7 @@ PHP_FUNCTION(mysqli_stmt_attr_get)
 	}
 
 #if MYSQL_VERSION_ID >= 50107
-	if (attr == STMT_ATTR_UPDATE_MAX_LENGTH)
+	if (!attr)
 		value = *((my_bool *)&value);
 #endif
 	RETURN_LONG((zend_ulong)value);
@@ -2397,7 +2397,7 @@ PHP_FUNCTION(mysqli_stmt_errno)
 	MY_STMT	*stmt;
 	zval	*mysql_stmt;
 
-	if (zend_parse_method_parameters(ZEND_NUM_ARGS(), getThis(), "O", &mysql_stmt, mysqli_stmt_class_entry) == FAILURE) {
+	if (!zend_parse_method_parameters(ZEND_NUM_ARGS(), getThis(), "O", &mysql_stmt, mysqli_stmt_class_entry)) {
 		return;
 	}
 	MYSQLI_FETCH_RESOURCE_STMT(stmt, mysql_stmt, MYSQLI_STATUS_INITIALIZED);
@@ -2414,7 +2414,7 @@ PHP_FUNCTION(mysqli_stmt_error)
 	zval 	*mysql_stmt;
 	const char * err;
 
-	if (zend_parse_method_parameters(ZEND_NUM_ARGS(), getThis(), "O", &mysql_stmt, mysqli_stmt_class_entry) == FAILURE) {
+	if (!zend_parse_method_parameters(ZEND_NUM_ARGS(), getThis(), "O", &mysql_stmt, mysqli_stmt_class_entry)) {
 		return;
 	}
 	MYSQLI_FETCH_RESOURCE_STMT(stmt, mysql_stmt, MYSQLI_STATUS_INITIALIZED);
@@ -2436,7 +2436,7 @@ PHP_FUNCTION(mysqli_stmt_init)
 	zval			*mysql_link;
 	MYSQLI_RESOURCE	*mysqli_resource;
 
-	if (zend_parse_method_parameters(ZEND_NUM_ARGS(), getThis(), "O",&mysql_link, mysqli_link_class_entry) == FAILURE) {
+	if (!zend_parse_method_parameters(ZEND_NUM_ARGS(), getThis(), "O", &mysql_link, mysqli_link_class_entry)) {
 		return;
 	}
 	MYSQLI_FETCH_RESOURCE_CONN(mysql, mysql_link, MYSQLI_STATUS_VALID);
@@ -2468,7 +2468,7 @@ PHP_FUNCTION(mysqli_stmt_prepare)
 	char	*query;
 	size_t		query_len;
 
-	if (zend_parse_method_parameters(ZEND_NUM_ARGS(), getThis(), "Os", &mysql_stmt, mysqli_stmt_class_entry, &query, &query_len) == FAILURE) {
+	if (!zend_parse_method_parameters(ZEND_NUM_ARGS(), getThis(), "Os", &mysql_stmt, mysqli_stmt_class_entry, &query, &query_len)) {
 		return;
 	}
 	MYSQLI_FETCH_RESOURCE_STMT(stmt, mysql_stmt, MYSQLI_STATUS_INITIALIZED);
@@ -2492,7 +2492,7 @@ PHP_FUNCTION(mysqli_stmt_result_metadata)
 	zval			*mysql_stmt;
 	MYSQLI_RESOURCE	*mysqli_resource;
 
-	if (zend_parse_method_parameters(ZEND_NUM_ARGS(), getThis(), "O", &mysql_stmt, mysqli_stmt_class_entry) == FAILURE) {
+	if (!zend_parse_method_parameters(ZEND_NUM_ARGS(), getThis(), "O", &mysql_stmt, mysqli_stmt_class_entry)) {
 		return;
 	}
 	MYSQLI_FETCH_RESOURCE_STMT(stmt, mysql_stmt, MYSQLI_STATUS_VALID);
@@ -2516,7 +2516,7 @@ PHP_FUNCTION(mysqli_stmt_store_result)
 	MY_STMT	*stmt;
 	zval	*mysql_stmt;
 
-	if (zend_parse_method_parameters(ZEND_NUM_ARGS(), getThis(), "O", &mysql_stmt, mysqli_stmt_class_entry) == FAILURE) {
+	if (!zend_parse_method_parameters(ZEND_NUM_ARGS(), getThis(), "O", &mysql_stmt, mysqli_stmt_class_entry)) {
 		return;
 	}
 	MYSQLI_FETCH_RESOURCE_STMT(stmt, mysql_stmt, MYSQLI_STATUS_VALID);
@@ -2566,7 +2566,7 @@ PHP_FUNCTION(mysqli_stmt_sqlstate)
 	zval	*mysql_stmt;
 	const char * state;
 
-	if (zend_parse_method_parameters(ZEND_NUM_ARGS(), getThis(), "O", &mysql_stmt, mysqli_stmt_class_entry) == FAILURE) {
+	if (!zend_parse_method_parameters(ZEND_NUM_ARGS(), getThis(), "O", &mysql_stmt, mysqli_stmt_class_entry)) {
 		return;
 	}
 	MYSQLI_FETCH_RESOURCE_STMT(stmt, mysql_stmt, MYSQLI_STATUS_VALID);
@@ -2589,7 +2589,7 @@ PHP_FUNCTION(mysqli_store_result)
 	zend_long flags = 0;
 
 
-	if (zend_parse_method_parameters(ZEND_NUM_ARGS(), getThis(), "O|l", &mysql_link, mysqli_link_class_entry, &flags) == FAILURE) {
+	if (!zend_parse_method_parameters(ZEND_NUM_ARGS(), getThis(), "O|l", &mysql_link, mysqli_link_class_entry, &flags)) {
 		return;
 	}
 	MYSQLI_FETCH_RESOURCE_CONN(mysql, mysql_link, MYSQLI_STATUS_VALID);
@@ -2620,7 +2620,7 @@ PHP_FUNCTION(mysqli_thread_id)
 	MY_MYSQL	*mysql;
 	zval		*mysql_link;
 
-	if (zend_parse_method_parameters(ZEND_NUM_ARGS(), getThis(), "O", &mysql_link, mysqli_link_class_entry) == FAILURE) {
+	if (!zend_parse_method_parameters(ZEND_NUM_ARGS(), getThis(), "O", &mysql_link, mysqli_link_class_entry)) {
 		return;
 	}
 	MYSQLI_FETCH_RESOURCE_CONN(mysql, mysql_link, MYSQLI_STATUS_VALID);
@@ -2635,7 +2635,7 @@ PHP_FUNCTION(mysqli_thread_safe)
 {
 	zval *mysql_link;
 
-	if (zend_parse_method_parameters(ZEND_NUM_ARGS(), getThis(), "O", &mysql_link, mysqli_link_class_entry) == FAILURE) {
+	if (!zend_parse_method_parameters(ZEND_NUM_ARGS(), getThis(), "O", &mysql_link, mysqli_link_class_entry)) {
 		return;
 	}
 
@@ -2652,7 +2652,7 @@ PHP_FUNCTION(mysqli_use_result)
 	zval			*mysql_link;
 	MYSQLI_RESOURCE	*mysqli_resource;
 
-	if (zend_parse_method_parameters(ZEND_NUM_ARGS(), getThis(), "O", &mysql_link, mysqli_link_class_entry) == FAILURE) {
+	if (!zend_parse_method_parameters(ZEND_NUM_ARGS(), getThis(), "O", &mysql_link, mysqli_link_class_entry)) {
 		return;
 	}
 	MYSQLI_FETCH_RESOURCE_CONN(mysql, mysql_link, MYSQLI_STATUS_VALID);
@@ -2679,7 +2679,7 @@ PHP_FUNCTION(mysqli_warning_count)
 	MY_MYSQL	*mysql;
 	zval		*mysql_link;
 
-	if (zend_parse_method_parameters(ZEND_NUM_ARGS(), getThis(), "O", &mysql_link, mysqli_link_class_entry) == FAILURE) {
+	if (!zend_parse_method_parameters(ZEND_NUM_ARGS(), getThis(), "O", &mysql_link, mysqli_link_class_entry)) {
 		return;
 	}
 	MYSQLI_FETCH_RESOURCE_CONN(mysql, mysql_link, MYSQLI_STATUS_VALID);

--- a/ext/mysqli/mysqli_api.c
+++ b/ext/mysqli/mysqli_api.c
@@ -656,7 +656,7 @@ PHP_FUNCTION(mysqli_character_set_name)
 {
 	MY_MYSQL	*mysql;
 	zval		*mysql_link;
-	const char	*cs_name;
+	char *cs_name;
 
 	if (!zend_parse_method_parameters(ZEND_NUM_ARGS(), getThis(), "O", &mysql_link, mysqli_link_class_entry)) {
 		return;
@@ -839,7 +839,7 @@ PHP_FUNCTION(mysqli_error)
 {
 	MY_MYSQL	*mysql;
 	zval		*mysql_link;
-	const char	*err;
+	char *err;
 
 	if (!zend_parse_method_parameters(ZEND_NUM_ARGS(), getThis(), "O", &mysql_link, mysqli_link_class_entry)) {
 		return;
@@ -1439,7 +1439,7 @@ PHP_FUNCTION(mysqli_get_server_info)
 {
 	MY_MYSQL	*mysql;
 	zval		*mysql_link = NULL;
-	const char	*info;
+	char *info;
 
 	if (!zend_parse_method_parameters(ZEND_NUM_ARGS(), getThis(), "O", &mysql_link, mysqli_link_class_entry)) {
 		return;
@@ -1475,7 +1475,7 @@ PHP_FUNCTION(mysqli_info)
 {
 	MY_MYSQL	*mysql;
 	zval		*mysql_link = NULL;
-	const char	*info;
+	char *info;
 
 	if (!zend_parse_method_parameters(ZEND_NUM_ARGS(), getThis(), "O", &mysql_link, mysqli_link_class_entry)) {
 		return;
@@ -2224,7 +2224,7 @@ PHP_FUNCTION(mysqli_sqlstate)
 {
 	MY_MYSQL	*mysql;
 	zval		*mysql_link;
-	const char	*state;
+	char *state;
 
 	if (!zend_parse_method_parameters(ZEND_NUM_ARGS(), getThis(), "O", &mysql_link, mysqli_link_class_entry)) {
 		return;
@@ -2412,7 +2412,7 @@ PHP_FUNCTION(mysqli_stmt_error)
 {
 	MY_STMT	*stmt;
 	zval 	*mysql_stmt;
-	const char * err;
+	char *err;
 
 	if (!zend_parse_method_parameters(ZEND_NUM_ARGS(), getThis(), "O", &mysql_stmt, mysqli_stmt_class_entry)) {
 		return;
@@ -2564,7 +2564,7 @@ PHP_FUNCTION(mysqli_stmt_sqlstate)
 {
 	MY_STMT	*stmt;
 	zval	*mysql_stmt;
-	const char * state;
+	char *state;
 
 	if (!zend_parse_method_parameters(ZEND_NUM_ARGS(), getThis(), "O", &mysql_stmt, mysqli_stmt_class_entry)) {
 		return;

--- a/ext/mysqli/mysqli_api.c
+++ b/ext/mysqli/mysqli_api.c
@@ -874,7 +874,7 @@ PHP_FUNCTION(mysqli_stmt_execute)
 			if (!Z_ISREF(stmt->param.vars[i])) {
 				continue;
 			}
-			for (j = i + 1; j < stmt->param.var_cnt; j++) {
+			for (j = i; j < stmt->param.var_cnt; j++) {
 				/* Oops, someone binding the same variable - clone */
 				if (Z_ISREF(stmt->param.vars[j]) &&
 					   	Z_REFVAL(stmt->param.vars[j]) == Z_REFVAL(stmt->param.vars[i])) {

--- a/ext/mysqli/mysqli_api.c
+++ b/ext/mysqli/mysqli_api.c
@@ -36,7 +36,8 @@
 /* {{{ mysqli_tx_cor_options_to_string */
 static void mysqli_tx_cor_options_to_string(const MYSQL * const conn, smart_str * str, const uint32_t mode)
 {
-	if (mode & TRANS_COR_AND_CHAIN && !(mode & TRANS_COR_AND_NO_CHAIN)) {
+	DEBUGASSERT(mode & TRANS_COR_AND_CHAIN);
+	if (!(mode & TRANS_COR_AND_NO_CHAIN)) {
 		if (str->s && ZSTR_LEN(str->s)) {
 			smart_str_appendl(str, " ", sizeof(" ") - 1);
 		}
@@ -48,7 +49,8 @@ static void mysqli_tx_cor_options_to_string(const MYSQL * const conn, smart_str 
 		smart_str_appendl(str, "AND NO CHAIN", sizeof("AND NO CHAIN") - 1);
 	}
 
-	if (mode & TRANS_COR_RELEASE && !(mode & TRANS_COR_NO_RELEASE)) {
+	DEBUGASSERT(mode & TRANS_COR_RELEASE);
+	if (!(mode & TRANS_COR_NO_RELEASE)) {
 		if (str->s && ZSTR_LEN(str->s)) {
 			smart_str_appendl(str, " ", sizeof(" ") - 1);
 		}
@@ -501,8 +503,8 @@ mysqli_stmt_bind_result_do_bind(MY_STMT *stmt, zval *args, unsigned int argc)
 					max_length to be updated. this is done only for BLOBS because we don't want to allocate
 					big chunkgs of memory 2^16 or 2^24
 				*/
-				if (stmt->stmt->fields[ofs].max_length == 0 &&
-					!mysql_stmt_attr_get(stmt->stmt, STMT_ATTR_UPDATE_MAX_LENGTH, &tmp) && !tmp)
+				DEBUGASSERT(stmt->stmt->fields[ofs].max_length == 0 && !mysql_stmt_attr_get(stmt->stmt, STMT_ATTR_UPDATE_MAX_LENGTH, &tmp));
+				if (!tmp)
 				{
 					/*
 					  Allocate directly 256 because it's easier to allocate a bit more
@@ -686,9 +688,8 @@ void php_mysqli_close(MY_MYSQL * mysql, int close_type, int resource_status)
 				mysqlnd_end_psession(mysql->mysql);
 #endif
 
-				if (MyG(rollback_on_cached_plink) &&
-#if !defined(MYSQLI_USE_MYSQLND)
-					mysqli_commit_or_rollback_libmysql(mysql->mysql, FALSE, TRANS_COR_NO_OPT, NULL))
+				DEBUGASSERT(MyG(rollback_on_cached_plink));
+				if (mysqli_commit_or_rollback_libmysql(mysql->mysql, FALSE, TRANS_COR_NO_OPT, NULL))
 #else
 					FAIL == mysqlnd_rollback(mysql->mysql, TRANS_COR_NO_OPT, NULL))
 #endif
@@ -1046,7 +1047,8 @@ void mysqli_stmt_fetch_libmysql(INTERNAL_FUNCTION_PARAMETERS)
 								llval= *(my_ulonglong *) stmt->result.buf[i].val;
 							}
 #if SIZEOF_ZEND_LONG==8
-							if (uns && llval > 9223372036854775807L) {
+							DEBUGASSERT(uns);
+							if (llval > 9223372036854775807L) {
 #elif SIZEOF_ZEND_LONG==4
 							if ((uns && llval > L64(2147483647)) ||
 								(!uns && (( L64(2147483647) < (my_longlong) llval) ||
@@ -1065,7 +1067,8 @@ void mysqli_stmt_fetch_libmysql(INTERNAL_FUNCTION_PARAMETERS)
 							}
 						} else {
 #if defined(MYSQL_DATA_TRUNCATED) && MYSQL_VERSION_ID > 50002
-							if (ret == MYSQL_DATA_TRUNCATED && *(stmt->stmt->bind[i].error) != 0) {
+							DEBUGASSERT(ret == MYSQL_DATA_TRUNCATED);
+							if (*(stmt->stmt->bind[i].error) != 0) {
 								/* result was truncated */
 								ZEND_TRY_ASSIGN_REF_STRINGL(result, stmt->result.buf[i].val, stmt->stmt->bind[i].buffer_length);
 							} else {


### PR DESCRIPTION
##  anilkoyuncu/ext_mysqli_mysqli_api.c_decl_stmt_7_12.cocci5 fix candidate

 @@
expression E0, E1;
@@
- if (E0 !=  E1)
+ if (strcmp(E0, E1) !=  0)
  {
  ...
  }
// Infered from: (php-src/{prevFiles/prev_867a794_549bba_ext#xmlrpc#xmlrpc-epi-php.c,revFiles/867a794_549bba_ext#xmlrpc#xmlrpc-epi-php.c}: PHP_FUNCTION), (php-src/{prevFiles/prev_e13d01_2f2fb60_ext#xmlrpc#xmlrpc-epi-php.c,revFiles/e13d01_2f2fb60_ext#xmlrpc#xmlrpc-epi-php.c}: PHP_FUNCTION)
// False positives: (php-src/revFiles/867a794_549bba_ext#xmlrpc#xmlrpc-epi-php.c: PHP_FUNCTION), (php-src/revFiles/e13d01_2f2fb60_ext#xmlrpc#xmlrpc-epi-php.c: PHP_FUNCTION)
// Recall: 0.67, Precision: 0.50, Matching recall: 1.00

// ---------------------------------------------

##  anilkoyuncu/ext_mysqli_mysqli_api.c_decl_stmt_7_12.cocci5 fix candidate

 @@
expression E0, E1, E3;
binary operator B2 = {+ ,- };
@@
- for(E0 = E1 B2 1;E0 < E3;E0++)
+ for(E0 = E1;E0 < E3;E0++)
  {
  ...
  }
// Infered from: (qemu/{prevFiles/prev_d6b6ab_d342eb_hw#nvram#fw_cfg.c,revFiles/d6b6ab_d342eb_hw#nvram#fw_cfg.c}: fw_cfg_modify_file), (codeflaws/{prevFiles/prev_38-A-14999208-14999227.c,revFiles/38-A-14999208-14999227.c}: main), (FFmpeg/{prevFiles/prev_bbc8f3_0c6105_libavfilter#vf_framerate.c,revFiles/bbc8f3_0c6105_libavfilter#vf_framerate.c}: uninit), (codeflaws/{prevFiles/prev_174-B-1501641-1501825.c,revFiles/174-B-1501641-1501825.c}: main)
// Recall: 0.50, Precision: 1.00, Matching recall: 1.00

// ---------------------------------------------

##  anilkoyuncu/ext_mysqli_mysqli_api.c_decl_stmt_7_12.cocci5 fix candidate

 @@
@@
- continue;
+ break;
// Infered from: (vlc/{prevFiles/prev_e96860_4dedfb_modules#demux#subtitle.c,revFiles/e96860_4dedfb_modules#demux#subtitle.c}: ParseJSS), (vlc/{prevFiles/prev_e96860_4dedfb_modules#demux#subtitle.c,revFiles/e96860_4dedfb_modules#demux#subtitle.c}: ParseJSS), (wireshark/{prevFiles/prev_71232b_203f12_epan#dissectors#packet-fix.c,revFiles/71232b_203f12_epan#dissectors#packet-fix.c}: dissect_fix_packet)
// False positives: (vlc/revFiles/e96860_4dedfb_modules#demux#subtitle.c: ParseJSS), (vlc/revFiles/e96860_4dedfb_modules#demux#subtitle.c: ParseRealText), (vlc/revFiles/e96860_4dedfb_modules#demux#subtitle.c: ParseSCC), (wireshark/revFiles/71232b_203f12_epan#dissectors#packet-fix.c: dissect_fix_packet)
// Recall: 1.00, Precision: 0.50, Matching recall: 1.00

// ---------------------------------------------
// Final metrics (for the combined 1 rules):
// -- Edit Location --
// Recall: 1.00, Precision: 0.67
// -- Node Change --
// Recall: 1.00, Precision: 0.50
// -- General --
// Functions fully changed: 2/6(33%)

/*
Functions where the patch produced incorrect changes:
 - vlc/prevFiles/prev_e96860_4dedfb_modules#demux#subtitle.c: ParseJSS
 - vlc/prevFiles/prev_e96860_4dedfb_modules#demux#subtitle.c: ParseRealText
 - vlc/prevFiles/prev_e96860_4dedfb_modules#demux#subtitle.c: ParseSCC
 - wireshark/prevFiles/prev_71232b_203f12_epan#dissectors#packet-fix.c: dissect_fix_packet
*/

// ---------------------------------------------

##  anilkoyuncu/ext_mysqli_mysqli_api.c_decl_stmt_7_12.cocci5 fix candidate

 @@
identifier I0;
expression E1;
@@
- const  char *I0 = E1;
// Infered from: (cairo/{prevFiles/prev_673102_f3574b_test#svg-clip.c,revFiles/673102_f3574b_test#svg-clip.c}: preamble), (cairo/{prevFiles/prev_673102_f3574b_test#png.c,revFiles/673102_f3574b_test#png.c}: preamble), (cairo/{prevFiles/prev_673102_f3574b_test#svg-surface.c,revFiles/673102_f3574b_test#svg-surface.c}: preamble)
// Recall: 0.50, Precision: 1.00, Matching recall: 0.50

// ---------------------------------------------
// Final metrics (for the combined 1 rules):
// -- Edit Location --
// Recall: 1.00, Precision: 1.00
// -- Node Change --
// Recall: 0.50, Precision: 1.00
// -- General --
// Functions fully changed: 0/3(0%)

/*
Functions where the patch applied partially:
 - cairo/prevFiles/prev_673102_f3574b_test#png.c: preamble
 - cairo/prevFiles/prev_673102_f3574b_test#svg-clip.c: preamble
 - cairo/prevFiles/prev_673102_f3574b_test#svg-surface.c: preamble
*/

// ---------------------------------------------

##  anilkoyuncu/ext_mysqli_mysqli_api.c_decl_stmt_7_12.cocci5 fix candidate

 @@
@@
- WRONG_PARAM_COUNT;
+ return;
// Infered from: (php-src/{prevFiles/prev_050f94_11c47d_ext#bcmath#bcmath.c,revFiles/050f94_11c47d_ext#bcmath#bcmath.c}: PHP_FUNCTION), (php-src/{prevFiles/prev_ddb4a6_bf2990_ext#standard#quot_print.c,revFiles/ddb4a6_bf2990_ext#standard#quot_print.c}: PHP_FUNCTION), (php-src/{prevFiles/prev_050f94_11c47d_ext#session#session.c,revFiles/050f94_11c47d_ext#session#session.c}: PHP_FUNCTION), (php-src/{prevFiles/prev_90c059_1e3e6c_ext#standard#quot_print.c,revFiles/90c059_1e3e6c_ext#standard#quot_print.c}: PHP_FUNCTION)
// False positives: (php-src/revFiles/050f94_11c47d_ext#bcmath#bcmath.c: PHP_FUNCTION), (php-src/revFiles/050f94_11c47d_ext#session#session.c: PHP_FUNCTION), (php-src/revFiles/369bf6_5c5d5d_ext#mysql#php_mysql.c: PHP_FUNCTION), (php-src/revFiles/369bf6_5c5d5d_ext#mysql#php_mysql.c: php_mysql_do_query), (php-src/revFiles/dfebf0_204989_ext#mysql#php_mysql.c: PHP_FUNCTION)
// Recall: 1.00, Precision: 0.44, Matching recall: 1.00

// ---------------------------------------------
// Final metrics (for the combined 1 rules):
// -- Edit Location --
// Recall: 1.00, Precision: 0.57
// -- Node Change --
// Recall: 1.00, Precision: 0.44
// -- General --
// Functions fully changed: 2/7(28%)

/*
Functions where the patch produced incorrect changes:
 - php-src/prevFiles/prev_dfebf0_204989_ext#mysql#php_mysql.c: PHP_FUNCTION
 - php-src/prevFiles/prev_050f94_11c47d_ext#session#session.c: PHP_FUNCTION
 - php-src/prevFiles/prev_369bf6_5c5d5d_ext#mysql#php_mysql.c: php_mysql_do_query
 - php-src/prevFiles/prev_050f94_11c47d_ext#bcmath#bcmath.c: PHP_FUNCTION
 - php-src/prevFiles/prev_369bf6_5c5d5d_ext#mysql#php_mysql.c: PHP_FUNCTION
*/

// ---------------------------------------------

##  anilkoyuncu/ext_mysqli_mysqli_api.c_decl_stmt_7_12.cocci5 fix candidate

 @@
expression E0, E1;
@@
- if (E0 && E1)
+ DEBUGASSERT(E0);
+ if (E1)
  {
  ...
  }
- else
+ else
  {
  ...
  }
// Infered from: (curl/{prevFiles/prev_39c296_dd7d71_lib#gopher.c,revFiles/39c296_dd7d71_lib#gopher.c}: gopher_do)
// Recall: 0.50, Precision: 1.00, Matching recall: 1.00

// ---------------------------------------------

##  anilkoyuncu/ext_mysqli_mysqli_api.c_decl_stmt_7_12.cocci5 fix candidate

 @@
identifier I1;
expression E0;
@@
- if (E0 == I1)
+ if (!E0)
  {
  ...
  }
// Infered from: (linux/{prevFiles/prev_4bb0142_38272d2_drivers#staging#rtl8192e#rtl819x_TSProc.c,revFiles/4bb0142_38272d2_drivers#staging#rtl8192e#rtl819x_TSProc.c}: SearchAdmitTRStream), (linux/{prevFiles/prev_597851_3408e9a_drivers#staging#lustre#lustre#ptlrpc#sec_bulk.c,revFiles/597851_3408e9a_drivers#staging#lustre#lustre#ptlrpc#sec_bulk.c}: enc_pools_add_pages), (linux/{prevFiles/prev_a0886f_2a7089d_drivers#staging#rtl8192u#ieee80211#rtl819x_TSProc.c,revFiles/a0886f_2a7089d_drivers#staging#rtl8192u#ieee80211#rtl819x_TSProc.c}: SearchAdmitTRStream), (linux/{prevFiles/prev_28f5ca_4e7c85_drivers#staging#rtl8723au#os_dep#xmit_linux.c,revFiles/28f5ca_4e7c85_drivers#staging#rtl8723au#os_dep#xmit_linux.c}: rtw_os_xmit_resource_alloc23a), (linux/{prevFiles/prev_e84d07_452975_drivers#staging#iio#trigger#iio-trig-periodic-rtc.c,revFiles/e84d07_452975_drivers#staging#iio#trigger#iio-trig-periodic-rtc.c}: iio_trig_periodic_rtc_probe), (linux/{prevFiles/prev_e84d07_452975_drivers#staging#iio#trigger#iio-trig-periodic-rtc.c,revFiles/e84d07_452975_drivers#staging#iio#trigger#iio-trig-periodic-rtc.c}: iio_trig_periodic_rtc_probe), (linux/{prevFiles/prev_6fae58f_cdf71c7_drivers#staging#iio#iio_dummy_evgen.c,revFiles/6fae58f_cdf71c7_drivers#staging#iio#iio_dummy_evgen.c}: iio_dummy_evgen_get_irq)
// False positives: (linux/revFiles/28f5ca_4e7c85_drivers#staging#rtl8723au#os_dep#xmit_linux.c: rtw_os_xmit_resource_alloc23a), (linux/revFiles/4bb0142_38272d2_drivers#staging#rtl8192e#rtl819x_TSProc.c: MakeTSEntry), (linux/revFiles/4bb0142_38272d2_drivers#staging#rtl8192e#rtl819x_TSProc.c: SearchAdmitTRStream), (linux/revFiles/597851_3408e9a_drivers#staging#lustre#lustre#ptlrpc#sec_bulk.c: bulk_sec_desc_unpack), (linux/revFiles/597851_3408e9a_drivers#staging#lustre#lustre#ptlrpc#sec_bulk.c: enc_pools_add_pages), (linux/revFiles/597851_3408e9a_drivers#staging#lustre#lustre#ptlrpc#sec_bulk.c: enc_pools_insert), (linux/revFiles/597851_3408e9a_drivers#staging#lustre#lustre#ptlrpc#sec_bulk.c: enc_pools_release_free_pages), (linux/revFiles/597851_3408e9a_drivers#staging#lustre#lustre#ptlrpc#sec_bulk.c: sptlrpc_enc_pool_get_pages), (linux/revFiles/597851_3408e9a_drivers#staging#lustre#lustre#ptlrpc#sec_bulk.c: sptlrpc_enc_pool_init), (linux/revFiles/597851_3408e9a_drivers#staging#lustre#lustre#ptlrpc#sec_bulk.c: sptlrpc_enc_pool_put_pages), (linux/revFiles/6fae58f_cdf71c7_drivers#staging#iio#iio_dummy_evgen.c: iio_dummy_evgen_create), (linux/revFiles/6fae58f_cdf71c7_drivers#staging#iio#iio_dummy_evgen.c: iio_dummy_evgen_get_irq), (linux/revFiles/a0886f_2a7089d_drivers#staging#rtl8192u#ieee80211#rtl819x_TSProc.c: MakeTSEntry), (linux/revFiles/a0886f_2a7089d_drivers#staging#rtl8192u#ieee80211#rtl819x_TSProc.c: SearchAdmitTRStream)
// Recall: 0.78, Precision: 0.26, Matching recall: 1.00

// ---------------------------------------------
// Final metrics (for the combined 1 rules):
// -- Edit Location --
// Recall: 0.75, Precision: 0.40
// -- Node Change --
// Recall: 0.78, Precision: 0.26
// -- General --
// Functions fully changed: 1/17(5%)

/*
Functions where the patch did not apply:
 - linux/prevFiles/prev_4bb0142_38272d2_drivers#staging#rtl8192e#rtl819x_TSProc.c: GetTs
 - linux/prevFiles/prev_a0886f_2a7089d_drivers#staging#rtl8192u#ieee80211#rtl819x_TSProc.c: GetTs
*/
/*
Functions where the patch produced incorrect changes:
 - linux/prevFiles/prev_a0886f_2a7089d_drivers#staging#rtl8192u#ieee80211#rtl819x_TSProc.c: MakeTSEntry
 - linux/prevFiles/prev_6fae58f_cdf71c7_drivers#staging#iio#iio_dummy_evgen.c: iio_dummy_evgen_get_irq
 - linux/prevFiles/prev_4bb0142_38272d2_drivers#staging#rtl8192e#rtl819x_TSProc.c: MakeTSEntry
 - linux/prevFiles/prev_a0886f_2a7089d_drivers#staging#rtl8192u#ieee80211#rtl819x_TSProc.c: SearchAdmitTRStream
 - linux/prevFiles/prev_597851_3408e9a_drivers#staging#lustre#lustre#ptlrpc#sec_bulk.c: bulk_sec_desc_unpack
 - linux/prevFiles/prev_597851_3408e9a_drivers#staging#lustre#lustre#ptlrpc#sec_bulk.c: sptlrpc_enc_pool_init
 - linux/prevFiles/prev_4bb0142_38272d2_drivers#staging#rtl8192e#rtl819x_TSProc.c: SearchAdmitTRStream
 - linux/prevFiles/prev_28f5ca_4e7c85_drivers#staging#rtl8723au#os_dep#xmit_linux.c: rtw_os_xmit_resource_alloc23a
 - linux/prevFiles/prev_597851_3408e9a_drivers#staging#lustre#lustre#ptlrpc#sec_bulk.c: enc_pools_release_free_pages
 - linux/prevFiles/prev_597851_3408e9a_drivers#staging#lustre#lustre#ptlrpc#sec_bulk.c: enc_pools_insert
 - linux/prevFiles/prev_597851_3408e9a_drivers#staging#lustre#lustre#ptlrpc#sec_bulk.c: sptlrpc_enc_pool_put_pages
 - linux/prevFiles/prev_6fae58f_cdf71c7_drivers#staging#iio#iio_dummy_evgen.c: iio_dummy_evgen_create
 - linux/prevFiles/prev_597851_3408e9a_drivers#staging#lustre#lustre#ptlrpc#sec_bulk.c: enc_pools_add_pages
 - linux/prevFiles/prev_597851_3408e9a_drivers#staging#lustre#lustre#ptlrpc#sec_bulk.c: sptlrpc_enc_pool_get_pages
*/

// ---------------------------------------------

##  anilkoyuncu/ext_mysqli_mysqli_api.c_decl_stmt_7_12.cocci5 fix candidate

 @@
identifier I0;
@@
- const  char *I0;
+ char *I0;
// Infered from: (vlc/{prevFiles/prev_cf0153_cc352b_modules#misc#lua#intf.c,revFiles/cf0153_cc352b_modules#misc#lua#intf.c}: Open_LuaIntf), (qemu/{prevFiles/prev_a2cb92_dc885f_block#sheepdog.c,revFiles/a2cb92_dc885f_block#sheepdog.c}: sd_co_create_opts), (qemu/{prevFiles/prev_890241_e5dc1a_tests#migration-test.c,revFiles/890241_e5dc1a_tests#migration-test.c}: migrate_check_parameter), (qemu/{prevFiles/prev_6e05a1_293811_hw#arm#vexpress.c,revFiles/6e05a1_293811_hw#arm#vexpress.c}: vexpress_common_init), (qemu/{prevFiles/prev_6e05a1_293811_hw#arm#virt.c,revFiles/6e05a1_293811_hw#arm#virt.c}: create_flash)
// False positives: (qemu/revFiles/890241_e5dc1a_tests#migration-test.c: ), (qemu/revFiles/890241_e5dc1a_tests#migration-test.c: test_migrate_start), (qemu/revFiles/890241_e5dc1a_tests#migration-test.c: wait_command), (qemu/revFiles/890241_e5dc1a_tests#migration-test.c: wait_for_migration_complete), (vlc/revFiles/cf0153_cc352b_modules#misc#lua#intf.c: GetModuleName)
// Recall: 0.38, Precision: 0.50, Matching recall: 0.67

// ---------------------------------------------
