### PR TITLE
build43165 fix candidate

### DIFF
--- a/ext/mysqli/mysqli_api.c
+++ b/ext/mysqli/mysqli_api.c
@@ -386,7 +386,6 @@ static int
 mysqli_stmt_bind_result_do_bind(MY_STMT *stmt, zval *args, unsigned int argc)
 {
 	MYSQL_BIND	*bind;
-	int			i, ofs;
 	int			var_cnt = argc;
 	zend_long		col_type;
 	zend_ulong		rc;
@@ -398,7 +397,6 @@ mysqli_stmt_bind_result_do_bind(MY_STMT *stmt, zval *args, unsigned int argc)
 
 	bind = (MYSQL_BIND *)ecalloc(var_cnt, sizeof(MYSQL_BIND));
 	{
-		int size;
 		char *p = emalloc(size= var_cnt * (sizeof(char) + sizeof(VAR_BUFFER)));
 		stmt->result.buf = (VAR_BUFFER *) p;
 		stmt->result.is_null = p + var_cnt * sizeof(VAR_BUFFER);


### PR DESCRIPTION
@@
identifier I0, I1;
@@
- int I0;
  ...
- int I1;
// Infered from: (cpython/{prevFiles/prev_d39d86_2841af_Python#pystrtod.c,revFiles/d39d86_2841af_Python#pystrtod.c}: PyOS_ascii_formatd)
// Recall: 0.20, Precision: 1.00, Matching recall: 0.67

// ---------------------------------------------