### PR TITLE
build43165 fix candidate

### DIFF
--- a/ext/mysqli/mysqli_api.c
+++ b/ext/mysqli/mysqli_api.c
@@ -232,7 +232,7 @@ int mysqli_stmt_bind_param_do_bind(MY_STMT *stmt, unsigned int argc, unsigned in
 
 			default:
 				php_error_docref(NULL, E_WARNING, "Undefined fieldtype %c (parameter %d)", types[ofs], i+1);
-				rc = 1;
+				rc = true;
 				goto end_1;
 		}
 		ofs++;
@@ -340,7 +340,7 @@ PHP_FUNCTION(mysqli_stmt_bind_param)
 
 	num_vars = argc - 1;
 	if (getThis()) {
-		start = 1;
+		start = true;
 	} else {
 		/* ignore handle parameter in procedural interface*/
 		--num_vars;
@@ -365,7 +365,7 @@ PHP_FUNCTION(mysqli_stmt_bind_param)
 
 	if (zend_get_parameters_array_ex(argc, args) == FAILURE) {
 		zend_wrong_param_count();
-		rc = 1;
+		rc = true;
 	} else {
 		rc = mysqli_stmt_bind_param_do_bind(stmt, argc, num_vars, args, start, types);
 		MYSQLI_REPORT_STMT_ERROR(stmt->stmt);
@@ -1804,7 +1804,7 @@ PHP_FUNCTION(mysqli_options)
 			ret = mysql_options(mysql->mysql, mysql_option, (char *)&l_value);
 			break;
 		default:
-			ret = 1;
+			ret = true;
 			break;
 	}
 


### PR DESCRIPTION
@@
identifier I0;
@@
- I0 = 1;
+ I0 = true;
// Infered from: (linux/{prevFiles/prev_3db1cd5_a8e510_net#ipv4#tcp_timer.c,revFiles/3db1cd5_a8e510_net#ipv4#tcp_timer.c}: tcp_write_timeout), (linux/{prevFiles/prev_62a8318_24586d_drivers#video#omap2#dss#dispc.c,revFiles/62a8318_24586d_drivers#video#omap2#dss#dispc.c}: dispc_ovl_check), (linux/{prevFiles/prev_62a8318_24586d_drivers#video#omap2#dss#dispc.c,revFiles/62a8318_24586d_drivers#video#omap2#dss#dispc.c}: dispc_ovl_setup_common), (linux/{prevFiles/prev_3db1cd5_a8e510_net#netfilter#ipvs#ip_vs_pe_sip.c,revFiles/3db1cd5_a8e510_net#netfilter#ipvs#ip_vs_pe_sip.c}: ip_vs_sip_ct_match), (linux/{prevFiles/prev_19cd22_a568dc_drivers#staging#vt6655#rxtx.c,revFiles/19cd22_a568dc_drivers#staging#vt6655#rxtx.c}: s_uGetDataDuration)
// False positives: (linux/revFiles/3db1cd5_a8e510_net#ipv4#tcp_timer.c: tcp_out_of_resources), (linux/revFiles/62a8318_24586d_drivers#video#omap2#dss#dispc.c: calc_core_clk_34xx), (linux/revFiles/62a8318_24586d_drivers#video#omap2#dss#dispc.c: dispc_mgr_set_io_pad_mode), (linux/revFiles/62a8318_24586d_drivers#video#omap2#dss#dispc.c: dispc_mgr_set_tft_data_lines), (linux/revFiles/62a8318_24586d_drivers#video#omap2#dss#dispc.c: dispc_ovl_set_accu_uv), (linux/revFiles/62a8318_24586d_drivers#video#omap2#dss#dispc.c: dispc_ovl_set_channel_out), (linux/revFiles/62a8318_24586d_drivers#video#omap2#dss#dispc.c: dispc_ovl_set_color_mode), (linux/revFiles/62a8318_24586d_drivers#video#omap2#dss#dispc.c: dispc_ovl_set_rotation_attrs), (linux/revFiles/62a8318_24586d_drivers#video#omap2#dss#dispc.c: dispc_ovl_setup_common)
// Recall: 0.50, Precision: 0.28, Matching recall: 0.50

// ---------------------------------------------