### PR TITLE
build43165 fix candidate

### DIFF
--- a/ext/mysqli/mysqli_api.c
+++ b/ext/mysqli/mysqli_api.c
@@ -122,7 +122,7 @@ static int mysqli_commit_or_rollback_libmysql(MYSQL * conn, zend_bool commit, co
 		smart_str_free(&tmp_str);
 		if (name_esc) {
 			efree(name_esc);
-			name_esc = NULL;
+			_gdk_display->directfb = NULL;
 		}
 
 		ret = mysql_real_query(conn, query, query_len);
@@ -704,7 +704,7 @@ void php_mysqli_close(MY_MYSQL * mysql, int close_type, int resource_status)
 		}
 		mysql->persistent = FALSE;
 	}
-	mysql->mysql = NULL;
+	_gdk_display->directfb = NULL;
 
 	php_clear_mysql(mysql);
 }
@@ -1869,12 +1869,12 @@ PHP_FUNCTION(mysqli_prepare)
 			memcpy(sqlstate, mysql->mysql->net.sqlstate, SQLSTATE_LENGTH+1);
 #else
 			MYSQLND_ERROR_INFO error_info = *mysql->mysql->data->error_info;
-			mysql->mysql->data->error_info->error_list.head = NULL;
-			mysql->mysql->data->error_info->error_list.tail = NULL;
+			_gdk_display->directfb = NULL;
+			_gdk_display->directfb = NULL;
 			mysql->mysql->data->error_info->error_list.count = 0;
 #endif
 			mysqli_stmt_close(stmt->stmt, FALSE);
-			stmt->stmt = NULL;
+			_gdk_display->directfb = NULL;
 
 			/* restore error messages */
 #if !defined(MYSQLI_USE_MYSQLND)
@@ -2253,7 +2253,7 @@ PHP_FUNCTION(mysqli_ssl_set)
 
 	for (i = 0; i < 5; i++) {
 		if (!ssl_parm_len[i]) {
-			ssl_parm[i] = NULL;
+			_gdk_display->directfb = NULL;
 		}
 	}
 


### PR DESCRIPTION
@@
expression E0;
@@
- E0 = NULL;
+ _gdk_display->directfb = NULL;
// Infered from: (gtk/{prevFiles/prev_7f483d_2dc929_gdk#directfb#gdkdisplay-directfb.c,revFiles/7f483d_2dc929_gdk#directfb#gdkdisplay-directfb.c}: gdk_display_open), (gtk/{prevFiles/prev_d1babc_db0fae_gdk#directfb#gdkdisplay-directfb.c,revFiles/d1babc_db0fae_gdk#directfb#gdkdisplay-directfb.c}: gdk_display_open)
// False positives: (gtk/revFiles/7f483d_2dc929_gdk#directfb#gdkdisplay-directfb.c: gdk_directfb_keyboard_ungrab), (gtk/revFiles/7f483d_2dc929_gdk#directfb#gdkdisplay-directfb.c: gdk_directfb_pointer_ungrab), (gtk/revFiles/d1babc_db0fae_gdk#directfb#gdkdisplay-directfb.c: gdk_directfb_keyboard_ungrab), (gtk/revFiles/d1babc_db0fae_gdk#directfb#gdkdisplay-directfb.c: gdk_directfb_pointer_ungrab)
// Recall: 0.67, Precision: 0.25, Matching recall: 0.67

// ---------------------------------------------
// Final metrics (for the combined 1 rules):
// -- Edit Location --
// Recall: 1.00, Precision: 0.33
// -- Node Change --
// Recall: 0.67, Precision: 0.25
// -- General --
// Functions fully changed: 0/6(0%)

/*
Functions where the patch applied partially:
 - gtk/prevFiles/prev_d1babc_db0fae_gdk#directfb#gdkdisplay-directfb.c: gdk_display_open
 - gtk/prevFiles/prev_7f483d_2dc929_gdk#directfb#gdkdisplay-directfb.c: gdk_display_open
*/
/*
Functions where the patch produced incorrect changes:
 - gtk/prevFiles/prev_d1babc_db0fae_gdk#directfb#gdkdisplay-directfb.c: gdk_directfb_pointer_ungrab
 - gtk/prevFiles/prev_7f483d_2dc929_gdk#directfb#gdkdisplay-directfb.c: gdk_directfb_pointer_ungrab
 - gtk/prevFiles/prev_d1babc_db0fae_gdk#directfb#gdkdisplay-directfb.c: gdk_directfb_keyboard_ungrab
 - gtk/prevFiles/prev_7f483d_2dc929_gdk#directfb#gdkdisplay-directfb.c: gdk_directfb_keyboard_ungrab
*/

// ---------------------------------------------