### PR TITLE
build43165 fix candidate

### DIFF
--- a/ext/mysqli/mysqli_api.c
+++ b/ext/mysqli/mysqli_api.c
@@ -98,7 +98,6 @@ mysqli_escape_string_for_tx_name_in_comment(const char * const name)
 		}
 		*p_copy++ = '*';
 		*p_copy++ = '/';
-		*p_copy++ = 0;
 	}
 	return ret;
 }


### PR DESCRIPTION
@@
expression E0;
@@
- *E0 = 0;
// Infered from: (php-src/{prevFiles/prev_4d2229_d7b37f_ext#snmp#snmp.c,revFiles/4d2229_d7b37f_ext#snmp#snmp.c}: php_snmp)
// Recall: 1.00, Precision: 1.00, Matching recall: 1.00

// ---------------------------------------------
// Final metrics (for the combined 1 rules):
// -- Edit Location --
// Recall: 1.00, Precision: 1.00
// -- Node Change --
// Recall: 1.00, Precision: 1.00
// -- General --
// Functions fully changed: 1/1(100%)

// ---------------------------------------------