### PR TITLE
build43165 fix candidate

### DIFF
--- a/ext/mysqli/mysqli_api.c
+++ b/ext/mysqli/mysqli_api.c
@@ -193,7 +193,6 @@ int mysqli_stmt_bind_param_do_bind(MY_STMT *stmt, unsigned int argc, unsigned in
 	stmt->param.is_null = ecalloc(num_vars, sizeof(char));
 	bind = (MYSQL_BIND *) ecalloc(num_vars, sizeof(MYSQL_BIND));
 
-	ofs = 0;
 	for (i = start; i < argc; i++) {
 		zval *param;
 		if (Z_ISREF(args[i])) {


### PR DESCRIPTION
@@
identifier I0;
@@
- I0 = 0;
// Infered from: (gstreamer/{prevFiles/prev_18c107_16fccf_gst#elements#gstbufferstore.c,revFiles/18c107_16fccf_gst#elements#gstbufferstore.c}: gst_buffer_store_get_buffer), (gstreamer/{prevFiles/prev_18c107_16fccf_gst#elements#gstbufferstore.c,revFiles/18c107_16fccf_gst#elements#gstbufferstore.c}: gst_buffer_store_get_size), (gstreamer/{prevFiles/prev_18c107_16fccf_plugins#elements#gstbufferstore.c,revFiles/18c107_16fccf_plugins#elements#gstbufferstore.c}: gst_buffer_store_get_buffer), (gstreamer/{prevFiles/prev_18c107_16fccf_plugins#elements#gstbufferstore.c,revFiles/18c107_16fccf_plugins#elements#gstbufferstore.c}: gst_buffer_store_get_size)
// Recall: 1.00, Precision: 1.00, Matching recall: 1.00

// ---------------------------------------------
// Final metrics (for the combined 1 rules):
// -- Edit Location --
// Recall: 1.00, Precision: 1.00
// -- Node Change --
// Recall: 1.00, Precision: 1.00
// -- General --
// Functions fully changed: 4/4(100%)

// ---------------------------------------------