### PR TITLE
build43165 fix candidate

### DIFF
--- a/ext/mysqli/mysqli_api.c
+++ b/ext/mysqli/mysqli_api.c
@@ -676,7 +676,7 @@ void php_mysqli_close(MY_MYSQL * mysql, int close_type, int resource_status)
 		MyG(num_links)--;
 	}
 
-	if (!mysql->persistent) {
+	if (mysql->persistent == NULL || *mysql->persistent == '\0') {
 		mysqli_close(mysql->mysql, close_type);
 	} else {
 		zend_resource *le;
@@ -973,7 +973,7 @@ void mysqli_stmt_fetch_libmysql(INTERNAL_FUNCTION_PARAMETERS)
 				continue; // but be safe ...
 			}
 			/* Even if the string is of length zero there is one byte alloced so efree() in all cases */
-			if (!stmt->result.is_null[i]) {
+			if (stmt->result.is_null[i] == NULL || *stmt->result.is_null[i] == '\0') {
 				switch (stmt->result.buf[i].type) {
 					case IS_LONG:
 						if ((stmt->stmt->fields[i].type == MYSQL_TYPE_LONG)
@@ -1523,7 +1523,7 @@ void php_mysqli_init(INTERNAL_FUNCTION_PARAMETERS, zend_bool is_method)
 	mysqli_resource->ptr = (void *)mysql;
 	mysqli_resource->status = MYSQLI_STATUS_INITIALIZED;
 
-	if (!is_method) {
+	if (is_method == NULL || *is_method == '\0') {
 		MYSQLI_RETURN_RESOURCE(mysqli_resource, mysqli_link_class_entry);
 	} else {
 		(Z_MYSQLI_P(getThis()))->ptr = mysqli_resource;


### PR DESCRIPTION
@@
expression E0;
@@
- if (E0 == NULL)
+ if (E0 == NULL || *E0 == 0)
  {
  ...
  }
- else
+ else
  {
  ...
  }
// Infered from: (tmux/{prevFiles/prev_474fde_9ced01_tty.c,revFiles/474fde_9ced01_tty.c}: tty_init), (tmux/{prevFiles/prev_182560_43ff21_tty.c,revFiles/182560_43ff21_tty.c}: tty_init)
// False positives: (git/revFiles/63e50d_ee24ee_builtin-apply.c: check_patch), (git/revFiles/63e50d_ee24ee_builtin-apply.c: parse_binary_hunk), (php-src/revFiles/cda7dc_6afcd6_main#streams#xp_socket.c: php_tcp_sockop_accept)
// Recall: 0.20, Precision: 0.33, Matching recall: 1.00

// ---------------------------------------------
// Final metrics (for the combined 7 rules):
// -- Edit Location --
// Recall: 1.00, Precision: 0.69
// -- Node Change --
// Recall: 1.00, Precision: 0.67
// -- General --
// Functions fully changed: 9/13(69%)

/*
Functions where the patch produced incorrect changes:
 - php-src/prevFiles/prev_cda7dc_6afcd6_main#streams#xp_socket.c: php_tcp_sockop_accept
 - git/prevFiles/prev_63e50d_ee24ee_builtin-apply.c: check_patch
 - git/prevFiles/prev_63e50d_ee24ee_builtin-apply.c: parse_binary_hunk
 - git/prevFiles/prev_63e50d_ee24ee_builtin-apply.c: gitdiff_index
*/

// ---------------------------------------------