### PR TITLE
build43165 fix candidate

### DIFF
--- a/ext/mysqli/mysqli_api.c
+++ b/ext/mysqli/mysqli_api.c
@@ -90,9 +90,10 @@ mysqli_escape_string_for_tx_name_in_comment(const char * const name)
 				v == '=')
 			{
 				*p_copy++ = v;
-			} else if (warned == FALSE) {
-				php_error_docref(NULL, E_WARNING, "Transaction name truncated. Must be only [0-9A-Za-z\\-_=]+");
-				warned = TRUE;
+			} else {if (warned == FALSE) {
+					php_error_docref(NULL, E_WARNING, "Transaction name truncated. Must be only [0-9A-Za-z\\-_=]+");
+					warned = TRUE;
+				}
 			}
 			++p_orig;
 		}
@@ -148,7 +149,7 @@ PHP_FUNCTION(mysqli_affected_rows)
 	MYSQLI_FETCH_RESOURCE_CONN(mysql, mysql_link, MYSQLI_STATUS_VALID);
 
 	rc = mysql_affected_rows(mysql->mysql);
-	if (rc == (my_ulonglong) -1) {
+	if (rc == (my_ulonglong)-1) {
 		RETURN_LONG(-1);
 	}
 	MYSQLI_RETURN_LONG_INT(rc);
@@ -331,8 +332,7 @@ PHP_FUNCTION(mysqli_stmt_bind_param)
 		WRONG_PARAM_COUNT;
 	}
 
-	if (zend_parse_method_parameters((getThis()) ? 1:2, getThis(), "Os", &mysql_stmt, mysqli_stmt_class_entry,
-									&types, &types_len) == FAILURE) {
+	if (zend_parse_method_parameters((getThis()) ? 1 : 2, getThis(), "Os", &mysql_stmt, mysqli_stmt_class_entry, &types, &types_len) == FAILURE) {
 		return;
 	}
 
@@ -1775,7 +1775,7 @@ PHP_FUNCTION(mysqli_options)
 
 #if !defined(MYSQLI_USE_MYSQLND)
 	if (PG(open_basedir) && PG(open_basedir)[0] != '\0') {
-		if(mysql_option == MYSQL_OPT_LOCAL_INFILE) {
+		if (mysql_option == MYSQL_OPT_LOCAL_INFILE) {
 			RETURN_FALSE;
 		}
 	}
@@ -1842,7 +1842,7 @@ PHP_FUNCTION(mysqli_prepare)
 	zval			*mysql_link;
 	MYSQLI_RESOURCE	*mysqli_resource;
 
-	if (zend_parse_method_parameters(ZEND_NUM_ARGS(), getThis(), "Os",&mysql_link, mysqli_link_class_entry, &query, &query_len) == FAILURE) {
+	if (zend_parse_method_parameters(ZEND_NUM_ARGS(), getThis(), "Os", &mysql_link, mysqli_link_class_entry, &query, &query_len) == FAILURE) {
 		return;
 	}
 	MYSQLI_FETCH_RESOURCE_CONN(mysql, mysql_link, MYSQLI_STATUS_VALID);
@@ -2042,7 +2042,7 @@ PHP_FUNCTION(mysqli_stmt_affected_rows)
 	MYSQLI_FETCH_RESOURCE_STMT(stmt, mysql_stmt, MYSQLI_STATUS_VALID);
 
 	rc = mysql_stmt_affected_rows(stmt->stmt);
-	if (rc == (my_ulonglong) -1) {
+	if (rc == (my_ulonglong)-1) {
 		RETURN_LONG(-1);
 	}
 	MYSQLI_RETURN_LONG_INT(rc)
@@ -2246,7 +2246,7 @@ PHP_FUNCTION(mysqli_ssl_set)
 	char		*ssl_parm[5];
 	size_t			ssl_parm_len[5], i;
 
-	if (zend_parse_method_parameters(ZEND_NUM_ARGS(), getThis(), "Osssss", &mysql_link, mysqli_link_class_entry, &ssl_parm[0], &ssl_parm_len[0], &ssl_parm[1], &ssl_parm_len[1], &ssl_parm[2], &ssl_parm_len[2], &ssl_parm[3], &ssl_parm_len[3], &ssl_parm[4], &ssl_parm_len[4])   == FAILURE) {
+	if (zend_parse_method_parameters(ZEND_NUM_ARGS(), getThis(), "Osssss", &mysql_link, mysqli_link_class_entry, &ssl_parm[0], &ssl_parm_len[0], &ssl_parm[1], &ssl_parm_len[1], &ssl_parm[2], &ssl_parm_len[2], &ssl_parm[3], &ssl_parm_len[3], &ssl_parm[4], &ssl_parm_len[4]) == FAILURE) {
 		return;
 	}
 	MYSQLI_FETCH_RESOURCE_CONN(mysql, mysql_link, MYSQLI_STATUS_INITIALIZED);
@@ -2436,7 +2436,7 @@ PHP_FUNCTION(mysqli_stmt_init)
 	zval			*mysql_link;
 	MYSQLI_RESOURCE	*mysqli_resource;
 
-	if (zend_parse_method_parameters(ZEND_NUM_ARGS(), getThis(), "O",&mysql_link, mysqli_link_class_entry) == FAILURE) {
+	if (zend_parse_method_parameters(ZEND_NUM_ARGS(), getThis(), "O", &mysql_link, mysqli_link_class_entry) == FAILURE) {
 		return;
 	}
 	MYSQLI_FETCH_RESOURCE_CONN(mysql, mysql_link, MYSQLI_STATUS_VALID);


### PR DESCRIPTION
@@
expression E0, E1;
@@
- if ((E0 == E1))
+ if (E0 == E1)
  {
  ...
  }
// Infered from: (wireshark/{prevFiles/prev_6ad633_ecf8cb_epan#dissectors#packet-tcp.c,revFiles/6ad633_ecf8cb_epan#dissectors#packet-tcp.c}: scan_for_next_pdu), (linux/{prevFiles/prev_0d20dac_a58af1_drivers#staging#rtl8188eu#core#rtw_security.c,revFiles/0d20dac_a58af1_drivers#staging#rtl8188eu#core#rtw_security.c}: rtw_aes_encrypt), (linux/{prevFiles/prev_0d20dac_a58af1_drivers#staging#rtl8188eu#core#rtw_security.c,revFiles/0d20dac_a58af1_drivers#staging#rtl8188eu#core#rtw_security.c}: rtw_aes_decrypt), (vlc/{prevFiles/prev_32b9c5_afea01_modules#access#zip#unzip#unzip.c,revFiles/32b9c5_afea01_modules#access#zip#unzip#unzip.c}: unzReadCurrentFile), (linux/{prevFiles/prev_6dc5aa_13ce3b_drivers#net#ethernet#broadcom#bnx2.c,revFiles/6dc5aa_13ce3b_drivers#net#ethernet#broadcom#bnx2.c}: bnx2_rx_int), (linux/{prevFiles/prev_eb5d2f_6fbef9_drivers#net#wireless#broadcom#brcm80211#brcmsmac#phy#phy_cmn.c,revFiles/eb5d2f_6fbef9_drivers#net#wireless#broadcom#brcm80211#brcmsmac#phy#phy_cmn.c}: read_radio_reg), (wireshark/{prevFiles/prev_6ad633_ecf8cb_epan#dissectors#packet-xml.c,revFiles/6ad633_ecf8cb_epan#dissectors#packet-xml.c}: xml_get_tag), (wireshark/{prevFiles/prev_6ad633_ecf8cb_epan#dissectors#packet-xml.c,revFiles/6ad633_ecf8cb_epan#dissectors#packet-xml.c}: xml_get_cdata), (wireshark/{prevFiles/prev_2ff1e3_d82e43_epan#dissectors#packet-pw-fr.c,revFiles/2ff1e3_d82e43_epan#dissectors#packet-pw-fr.c}: dissect_pw_fr), (wireshark/{prevFiles/prev_d82e43_d8b480_epan#dissectors#packet-isup.c,revFiles/d82e43_d8b480_epan#dissectors#packet-isup.c}: dissect_isup_application_transport_parameter)
// False positives: (linux/revFiles/cfed0a2c_9a8a02c_drivers#net#ethernet#mellanox#mlx4#port.c: __mlx4_register_mac), (wireshark/revFiles/2e84d2_eeafb4_epan#dissectors#packet-gtp.c: track_gtp_session)
// Recall: 0.46, Precision: 0.83, Matching recall: 0.92

// ---------------------------------------------