### PR TITLE
build43165 fix candidate

### DIFF
--- a/ext/mysqli/mysqli_api.c
+++ b/ext/mysqli/mysqli_api.c
@@ -107,7 +107,7 @@ mysqli_escape_string_for_tx_name_in_comment(const char * const name)
 /* {{{ mysqli_commit_or_rollback_libmysql */
 static int mysqli_commit_or_rollback_libmysql(MYSQL * conn, zend_bool commit, const uint32_t mode, const char * const name)
 {
-	int ret;
+	Py_ssize_t ret;
 	smart_str tmp_str = {0};
 	mysqli_tx_cor_options_to_string(conn, &tmp_str, mode);
 	smart_str_0(&tmp_str);
@@ -317,7 +317,7 @@ PHP_FUNCTION(mysqli_stmt_bind_param)
 {
 	zval			*args;
 	int				argc = ZEND_NUM_ARGS();
-	int				num_vars;
+	Py_ssize_t num_vars;
 	int				start = 2;
 	MY_STMT			*stmt;
 	zval			*mysql_stmt;
@@ -398,7 +398,7 @@ mysqli_stmt_bind_result_do_bind(MY_STMT *stmt, zval *args, unsigned int argc)
 
 	bind = (MYSQL_BIND *)ecalloc(var_cnt, sizeof(MYSQL_BIND));
 	{
-		int size;
+		Py_ssize_t size;
 		char *p = emalloc(size= var_cnt * (sizeof(char) + sizeof(VAR_BUFFER)));
 		stmt->result.buf = (VAR_BUFFER *) p;
 		stmt->result.is_null = p + var_cnt * sizeof(VAR_BUFFER);
@@ -581,7 +581,7 @@ mysqli_stmt_bind_result_do_bind(MY_STMT *stmt, zval *args, unsigned int argc)
 PHP_FUNCTION(mysqli_stmt_bind_result)
 {
 	zval		*args;
-	int			argc;
+	Py_ssize_t argc;
 	zend_ulong		rc;
 	MY_STMT		*stmt;
 	zval		*mysql_stmt;
@@ -869,7 +869,7 @@ PHP_FUNCTION(mysqli_stmt_execute)
 
 #ifndef MYSQLI_USE_MYSQLND
 	if (stmt->param.var_cnt) {
-		int j;
+		Py_ssize_t j;
 		for (i = 0; i < stmt->param.var_cnt; i++) {
 			if (!Z_ISREF(stmt->param.vars[i])) {
 				continue;
@@ -1766,7 +1766,7 @@ PHP_FUNCTION(mysqli_options)
 	zend_long			mysql_option;
 	unsigned int	l_value;
 	zend_long			ret;
-	int				expected_type;
+	Py_ssize_t expected_type;
 
 	if (zend_parse_method_parameters(ZEND_NUM_ARGS(), getThis(), "Olz", &mysql_link, mysqli_link_class_entry, &mysql_option, &mysql_value) == FAILURE) {
 		return;
@@ -2371,7 +2371,7 @@ PHP_FUNCTION(mysqli_stmt_attr_get)
 	zval	*mysql_stmt;
 	zend_ulong	value = 0;
 	zend_long	attr;
-	int		rc;
+	Py_ssize_t rc;
 
 	if (zend_parse_method_parameters(ZEND_NUM_ARGS(), getThis(), "Ol", &mysql_stmt, mysqli_stmt_class_entry, &attr) == FAILURE) {
 		return;


### PR DESCRIPTION
@@
identifier I0;
typedef Py_ssize_t;
@@
- int I0;
+ Py_ssize_t I0;
// Infered from: (cpython/{prevFiles/prev_668512_26fd96_Modules#_codecsmodule.c,revFiles/668512_26fd96_Modules#_codecsmodule.c}: escape_encode)
// Recall: 0.17, Precision: 1.00, Matching recall: 1.00

// ---------------------------------------------
// Final metrics (for the combined 1 rules):
// -- Edit Location --
// Recall: 0.25, Precision: 1.00
// -- Node Change --
// Recall: 0.17, Precision: 1.00
// -- General --
// Functions fully changed: 1/4(25%)

/*
Functions where the patch did not apply:
 - ompi/prevFiles/prev_8a3abb_ea7e1e_ompi#mca#io#romio321#src#io_romio321_module.c:
 - ompi/prevFiles/prev_8a3abb_ea7e1e_ompi#mca#io#romio321#src#io_romio321_module.c: MPIR_Status_set_bytes
 - cpython/prevFiles/prev_668512_26fd96_Modules#_codecsmodule.c: codec_tuple
*/

// ---------------------------------------------