### PR TITLE
build43165 fix candidate

### DIFF
--- a/ext/mysqli/mysqli_api.c
+++ b/ext/mysqli/mysqli_api.c
@@ -70,9 +70,7 @@ mysqli_escape_string_for_tx_name_in_comment(const char * const name)
 	char * ret = NULL;
 	if (name) {
 		zend_bool warned = FALSE;
-		const char * p_orig = name;
-		char * p_copy;
-		p_copy = ret = emalloc(strlen(name) + 1 + 2 + 2 + 1); /* space, open, close, NullS */
+		const char * p_orig = name;/* space, open, close, NullS */
 		*p_copy++ = ' ';
 		*p_copy++ = '/';
 		*p_copy++ = '*';


### PR DESCRIPTION
@@
identifier I0;
expression E1;
@@
- char *I0;
- I0 = E1;
// Infered from: (openssl/{prevFiles/prev_c8bbd9_57ae37_crypto#conf#conf_def.c,revFiles/c8bbd9_57ae37_crypto#conf#conf_def.c}: clear_comments)
// Recall: 0.29, Precision: 1.00, Matching recall: 1.00

// ---------------------------------------------
// Final metrics (for the combined 1 rules):
// -- Edit Location --
// Recall: 0.25, Precision: 1.00
// -- Node Change --
// Recall: 0.29, Precision: 1.00
// -- General --
// Functions fully changed: 1/4(25%)

/*
Functions where the patch did not apply:
 - wireshark/prevFiles/prev_7c1b5e_f79870_epan#dissectors#packet-flip.c: dissect_flip_chksum_hdr
 - wireshark/prevFiles/prev_7c1b5e_f79870_epan#dissectors#packet-flip.c: dissect_flip
*/

// ---------------------------------------------