### PR TITLE
build43165 fix candidate

### DIFF
--- a/ext/mysqli/mysqli_api.c
+++ b/ext/mysqli/mysqli_api.c
@@ -682,7 +682,7 @@ void php_mysqli_close(MY_MYSQL * mysql, int close_type, int resource_status)
 		zend_resource *le;
 		if ((le = zend_hash_find_ptr(&EG(persistent_list), mysql->hash_key)) != NULL) {
 			if (le->type == php_le_pmysqli()) {
-				mysqli_plist_entry *plist = (mysqli_plist_entry *) le->ptr;
+				mysqli_plist_entry *plist = le->ptr;
 #if defined(MYSQLI_USE_MYSQLND)
 				mysqlnd_end_psession(mysql->mysql);
 #endif


### PR DESCRIPTION
@@
identifier I1;
type T0, T2;
expression E3;
@@
- T0 *I1 = (T2 *)E3;
+ T0 *I1 = E3;
// Infered from: (linux/{prevFiles/prev_4d962d_80fe133_drivers#staging#media#atomisp#pci#atomisp2#css2400#sh_css_firmware.c,revFiles/4d962d_80fe133_drivers#staging#media#atomisp#pci#atomisp2#css2400#sh_css_firmware.c}: sh_css_load_blob_info), (linux/{prevFiles/prev_41ced61_12f2a4_drivers#net#ethernet#altera#altera_tse_main.c,revFiles/41ced61_12f2a4_drivers#net#ethernet#altera#altera_tse_main.c}: altera_tse_set_mcfilter), (linux/{prevFiles/prev_41ced61_12f2a4_drivers#net#ethernet#altera#altera_tse_main.c,revFiles/41ced61_12f2a4_drivers#net#ethernet#altera#altera_tse_main.c}: altera_tse_set_mcfilterall), (linux/{prevFiles/prev_1851cb_45d18c_drivers#net#wireless#rtlwifi#rtl8723be#trx.c,revFiles/1851cb_45d18c_drivers#net#wireless#rtlwifi#rtl8723be#trx.c}: rtl8723be_tx_fill_desc), (linux/{prevFiles/prev_866af46_7e8e80_drivers#staging#media#atomisp#pci#atomisp2#css2400#sh_css_firmware.c,revFiles/866af46_7e8e80_drivers#staging#media#atomisp#pci#atomisp2#css2400#sh_css_firmware.c}: sh_css_load_blob_info), (linux/{prevFiles/prev_1851cb_45d18c_drivers#net#wireless#rtlwifi#rtl8188ee#fw.c,revFiles/1851cb_45d18c_drivers#net#wireless#rtlwifi#rtl8188ee#fw.c}: _rtl88e_write_fw), (linux/{prevFiles/prev_1851cb_45d18c_drivers#net#wireless#rtlwifi#rtl8188ee#trx.c,revFiles/1851cb_45d18c_drivers#net#wireless#rtlwifi#rtl8188ee#trx.c}: rtl88ee_tx_fill_desc), (FFmpeg/{prevFiles/prev_d506de_284cfc_libavutil#fixed_dsp.c,revFiles/d506de_284cfc_libavutil#fixed_dsp.c}: avpriv_alloc_fixed_dsp), (linux/{prevFiles/prev_c2fd03_2c20889_drivers#net#hyperv#netvsc.c,revFiles/c2fd03_2c20889_drivers#net#hyperv#netvsc.c}: netvsc_receive_completion), (vlc/{prevFiles/prev_2d91e6_feaa55_modules#services_discovery#sap.c,revFiles/2d91e6_feaa55_modules#services_discovery#sap.c}: ParseSDP), (linux/{prevFiles/prev_8f47c2_86d7b2_drivers#staging#rtl8712#xmit_linux.c,revFiles/8f47c2_86d7b2_drivers#staging#rtl8712#xmit_linux.c}: r8712_xmit_entry), (linux/{prevFiles/prev_e31926_29a6b6_net#atm#lec.c,revFiles/e31926_29a6b6_net#atm#lec.c}: lec_arp_expire_vcc), (linux/{prevFiles/prev_898699_9cb76aa_drivers#net#wireless#ath#carl9170#rx.c,revFiles/898699_9cb76aa_drivers#net#wireless#ath#carl9170#rx.c}: carl9170_ba_check), (linux/{prevFiles/prev_324148_a05d08_drivers#staging#rt2860#common#cmm_data.c,revFiles/324148_a05d08_drivers#staging#rt2860#common#cmm_data.c}: deaggregate_AMSDU_announce), (linux/{prevFiles/prev_1851cb_45d18c_drivers#net#wireless#rtlwifi#rtl8723ae#trx.c,revFiles/1851cb_45d18c_drivers#net#wireless#rtlwifi#rtl8723ae#trx.c}: rtl8723ae_tx_fill_desc), (linux/{prevFiles/prev_324148_a05d08_drivers#staging#rt2860#common#cmm_mac_usb.c,revFiles/324148_a05d08_drivers#staging#rt2860#common#cmm_mac_usb.c}: RT28xxUsbMlmeRadioOFF), (linux/{prevFiles/prev_1851cb_45d18c_drivers#net#wireless#rtlwifi#rtl8723com#fw_common.c,revFiles/1851cb_45d18c_drivers#net#wireless#rtlwifi#rtl8723com#fw_common.c}: rtl8723_write_fw), (linux/{prevFiles/prev_324148_a05d08_drivers#staging#rt2860#common#cmm_mac_pci.c,revFiles/324148_a05d08_drivers#staging#rt2860#common#cmm_mac_pci.c}: RT28xxPciMlmeRadioOFF), (linux/{prevFiles/prev_c2fd03_2c20889_drivers#net#appletalk#cops.c,revFiles/c2fd03_2c20889_drivers#net#appletalk#cops.c}: cops_ioctl), (linux/{prevFiles/prev_e31926_29a6b6_net#mac80211#scan.c,revFiles/e31926_29a6b6_net#mac80211#scan.c}: ieee80211_bss_info_update)
// False positives: (FFmpeg/revFiles/c004de_103410_libavcodec#gifdec.c: gif_fill), (linux/revFiles/1851cb_45d18c_drivers#net#wireless#rtlwifi#rtl8188ee#fw.c: _rtl88e_fw_block_write), (linux/revFiles/1851cb_45d18c_drivers#net#wireless#rtlwifi#rtl8188ee#trx.c: _rtl88ee_query_rxphystatus), (linux/revFiles/1851cb_45d18c_drivers#net#wireless#rtlwifi#rtl8188ee#trx.c: rtl88ee_tx_fill_cmddesc), (linux/revFiles/1851cb_45d18c_drivers#net#wireless#rtlwifi#rtl8723ae#trx.c: rtl8723ae_tx_fill_cmddesc), (linux/revFiles/1851cb_45d18c_drivers#net#wireless#rtlwifi#rtl8723be#trx.c: _rtl8723be_query_rxphystatus), (linux/revFiles/1851cb_45d18c_drivers#net#wireless#rtlwifi#rtl8723be#trx.c: rtl8723be_is_tx_desc_closed), (linux/revFiles/1851cb_45d18c_drivers#net#wireless#rtlwifi#rtl8723com#fw_common.c: rtl8723_fw_block_write), (linux/revFiles/324148_a05d08_drivers#staging#rt2860#common#cmm_mac_pci.c: PsPollWakeExec), (linux/revFiles/324148_a05d08_drivers#staging#rt2860#common#cmm_mac_pci.c: RadioOnExec), (linux/revFiles/324148_a05d08_drivers#staging#rt2860#common#cmm_mac_usb.c: BeaconUpdateExec), (linux/revFiles/324148_a05d08_drivers#staging#rt2860#common#cmm_mac_usb.c: NICInitRecv), (linux/revFiles/324148_a05d08_drivers#staging#rt2860#common#cmm_mac_usb.c: NICInitTransmit), (linux/revFiles/324148_a05d08_drivers#staging#rt2860#common#cmm_mac_usb.c: RTMPFreeTxRxRingMemory), (linux/revFiles/41ced61_12f2a4_drivers#net#ethernet#altera#altera_tse_main.c: altera_tse_mdio_read), (linux/revFiles/41ced61_12f2a4_drivers#net#ethernet#altera#altera_tse_main.c: altera_tse_mdio_write), (linux/revFiles/898699_9cb76aa_drivers#net#wireless#ath#carl9170#rx.c: carl9170_ba_check), (linux/revFiles/898699_9cb76aa_drivers#net#wireless#ath#carl9170#rx.c: carl9170_find_ie), (linux/revFiles/898699_9cb76aa_drivers#net#wireless#ath#carl9170#rx.c: carl9170_rx_copy_data), (linux/revFiles/c2fd03_2c20889_drivers#net#appletalk#cops.c: cops_ioctl), (linux/revFiles/c2fd03_2c20889_drivers#net#appletalk#cops.c: cops_load), (linux/revFiles/c2fd03_2c20889_drivers#net#appletalk#cops.c: cops_poll), (linux/revFiles/e31926_29a6b6_net#atm#lec.c: lec_arp_check_empties), (linux/revFiles/e31926_29a6b6_net#atm#lec.c: lec_arp_clear_vccs), (linux/revFiles/e31926_29a6b6_net#atm#lec.c: lec_arp_expire_vcc), (linux/revFiles/e31926_29a6b6_net#atm#lec.c: lec_atm_close), (linux/revFiles/e31926_29a6b6_net#atm#lec.c: lec_atm_send), (linux/revFiles/e31926_29a6b6_net#atm#lec.c: lec_push), (linux/revFiles/e31926_29a6b6_net#mac80211#scan.c: ieee80211_rx_bss_free), (vlc/revFiles/2d91e6_feaa55_modules#services_discovery#sap.c: Close), (vlc/revFiles/2d91e6_feaa55_modules#services_discovery#sap.c: CreateAnnounce), (vlc/revFiles/2d91e6_feaa55_modules#services_discovery#sap.c: Demux), (vlc/revFiles/2d91e6_feaa55_modules#services_discovery#sap.c: Open), (vlc/revFiles/2d91e6_feaa55_modules#services_discovery#sap.c: OpenDemux), (vlc/revFiles/2d91e6_feaa55_modules#services_discovery#sap.c: RemoveAnnounce)
// Recall: 0.70, Precision: 0.32, Matching recall: 0.91

// ---------------------------------------------