### PR TITLE
build43165 fix candidate

### DIFF
--- a/ext/mysqli/mysqli_api.c
+++ b/ext/mysqli/mysqli_api.c
@@ -1968,7 +1968,7 @@ PHP_FUNCTION(mysqli_real_escape_string) {
 	}
 	MYSQLI_FETCH_RESOURCE_CONN(mysql, mysql_link, MYSQLI_STATUS_VALID);
 
-	newstr = zend_string_alloc(2 * escapestr_len, 0);
+	newstr = zend_string_safe_alloc(1, 2 * escapestr_len, 0, 0);
 	ZSTR_LEN(newstr) = mysql_real_escape_string(mysql->mysql, ZSTR_VAL(newstr), escapestr, escapestr_len);
 	newstr = zend_string_truncate(newstr, ZSTR_LEN(newstr), 0);
 


### PR DESCRIPTION
@@
expression E0, E1;
@@
- E0 = zend_string_alloc(E1, 0);
+ E0 = zend_string_safe_alloc(1, E1, 0, 0);
// Infered from: (php-src/{prevFiles/prev_ccc12e_c89b7a_ext#zip#php_zip.c,revFiles/ccc12e_c89b7a_ext#zip#php_zip.c}: php_zip_get_from)
// Recall: 0.50, Precision: 1.00, Matching recall: 1.00

// ---------------------------------------------