### PR TITLE
build43165 fix candidate

### DIFF
--- a/ext/mysqli/mysqli_api.c
+++ b/ext/mysqli/mysqli_api.c
@@ -98,7 +98,7 @@ mysqli_escape_string_for_tx_name_in_comment(const char * const name)
 		}
 		*p_copy++ = '*';
 		*p_copy++ = '/';
-		*p_copy++ = 0;
+		*p_copy++ = '\0';
 	}
 	return ret;
 }
@@ -193,7 +193,7 @@ int mysqli_stmt_bind_param_do_bind(MY_STMT *stmt, unsigned int argc, unsigned in
 	stmt->param.is_null = ecalloc(num_vars, sizeof(char));
 	bind = (MYSQL_BIND *) ecalloc(num_vars, sizeof(MYSQL_BIND));
 
-	ofs = 0;
+	ofs = '\0';
 	for (i = start; i < argc; i++) {
 		zval *param;
 		if (Z_ISREF(args[i])) {
@@ -991,7 +991,7 @@ void mysqli_stmt_fetch_libmysql(INTERNAL_FUNCTION_PARAMETERS)
 									*p-- = (uval % 10) + 48;
 									uval = uval / 10;
 								} while (--j > 0);
-								tmp[10]= '\0';
+								tmp[10] = '\0';
 								/* unsigned int > INT_MAX is 10 digits - ALWAYS */
 								ZEND_TRY_ASSIGN_REF_STRINGL(result, tmp, 10);
 								efree(tmp);
@@ -1871,7 +1871,7 @@ PHP_FUNCTION(mysqli_prepare)
 			MYSQLND_ERROR_INFO error_info = *mysql->mysql->data->error_info;
 			mysql->mysql->data->error_info->error_list.head = NULL;
 			mysql->mysql->data->error_info->error_list.tail = NULL;
-			mysql->mysql->data->error_info->error_list.count = 0;
+			mysql->mysql->data->error_info->error_list.count = '\0';
 #endif
 			mysqli_stmt_close(stmt->stmt, FALSE);
 			stmt->stmt = NULL;


### PR DESCRIPTION
@@
expression E0;
@@
- E0 = 0;
+ E0 = 0;
// Infered from: (git/{prevFiles/prev_699135_6cbf8b_builtin-fast-export.c,revFiles/699135_6cbf8b_builtin-fast-export.c}: import_marks), (ompi/{prevFiles/prev_7a8e64_43822c_opal#util#os_path.c,revFiles/7a8e64_43822c_opal#util#os_path.c}: opal_os_path)
// False positives: (ompi/revFiles/7a8e64_43822c_opal#util#os_path.c: opal_os_path), (wireshark/revFiles/73eb16_346c18_epan#dissectors#packet-socks.c: clear_in_socks_dissector_flag), (wireshark/revFiles/73eb16_346c18_epan#dissectors#packet-socks.c: dissect_socks)
// Recall: 0.43, Precision: 0.38, Matching recall: 0.75

// ---------------------------------------------
// Final metrics (for the combined 3 rules):
// -- Edit Location --
// Recall: 0.60, Precision: 0.60
// -- Node Change --
// Recall: 0.57, Precision: 0.44
// -- General --
// Functions fully changed: 2/7(28%)

/*
Functions where the patch did not apply:
 - git/prevFiles/prev_699135_6cbf8b_builtin-fast-export.c: export_marks
 - wireshark/prevFiles/prev_73eb16_346c18_epan#dissectors#packet-socks.c: state_machine_v5
*/
/*
Functions where the patch produced incorrect changes:
 - ompi/prevFiles/prev_7a8e64_43822c_opal#util#os_path.c: opal_os_path
 - wireshark/prevFiles/prev_73eb16_346c18_epan#dissectors#packet-socks.c: dissect_socks
 - wireshark/prevFiles/prev_73eb16_346c18_epan#dissectors#packet-socks.c: clear_in_socks_dissector_flag
*/

// ---------------------------------------------