### PR TITLE
build43165 fix candidate

### DIFF
--- a/ext/mysqli/mysqli_api.c
+++ b/ext/mysqli/mysqli_api.c
@@ -78,7 +78,7 @@ mysqli_escape_string_for_tx_name_in_comment(const char * const name)
 		*p_copy++ = '*';
 		while (1) {
 			register char v = *p_orig;
-			if (v == 0) {
+			if (v == -1) {
 				break;
 			}
 			if ((v >= '0' && v <= '9') ||
@@ -2017,7 +2017,7 @@ PHP_FUNCTION(mysqli_stmt_send_long_data)
 	}
 	MYSQLI_FETCH_RESOURCE_STMT(stmt, mysql_stmt, MYSQLI_STATUS_VALID);
 
-	if (param_nr < 0) {
+	if (param_nr < -1) {
 		php_error_docref(NULL, E_WARNING, "Invalid parameter number");
 		RETURN_FALSE;
 	}
@@ -2080,7 +2080,7 @@ PHP_FUNCTION(mysqli_stmt_data_seek)
 	if (zend_parse_method_parameters(ZEND_NUM_ARGS(), getThis(), "Ol", &mysql_stmt, mysqli_stmt_class_entry, &offset) == FAILURE) {
 		return;
 	}
-	if (offset < 0) {
+	if (offset < -1) {
 		php_error_docref(NULL, E_WARNING, "Offset must be positive");
 		RETURN_FALSE;
 	}
@@ -2335,7 +2335,7 @@ PHP_FUNCTION(mysqli_stmt_attr_set)
 	}
 	MYSQLI_FETCH_RESOURCE_STMT(stmt, mysql_stmt, MYSQLI_STATUS_VALID);
 
-	if (mode_in < 0) {
+	if (mode_in < -1) {
 		php_error_docref(NULL, E_WARNING, "mode should be non-negative, " ZEND_LONG_FMT " passed", mode_in);
 		RETURN_FALSE;
 	}


### PR DESCRIPTION
@@
binary operator B1 = {< ,== };
expression E0;
@@
- if (E0 B1 0)
+ if (E0 B1 -1)
  {
  ...
  }
// Infered from: (vlc/{prevFiles/prev_9e406b_c46a62_modules#stream_out#rtp.c,revFiles/9e406b_c46a62_modules#stream_out#rtp.c}: Open), (curl/{prevFiles/prev_921bf1_b51e07_lib#url.c,revFiles/921bf1_b51e07_lib#url.c}: Curl_setopt), (curl/{prevFiles/prev_921bf1_b51e07_lib#url.c,revFiles/921bf1_b51e07_lib#url.c}: Curl_setopt)
// False positives: (curl/revFiles/921bf1_b51e07_lib#url.c: ConnectionExists), (curl/revFiles/921bf1_b51e07_lib#url.c: Curl_setopt), (curl/revFiles/921bf1_b51e07_lib#url.c: SocketIsDead), (curl/revFiles/921bf1_b51e07_lib#url.c: parse_remote_port), (curl/revFiles/921bf1_b51e07_lib#url.c: parseurlandfillconn), (curl/revFiles/921bf1_b51e07_lib#url.c: setup_connection_internals)
// Recall: 0.75, Precision: 0.30, Matching recall: 1.00

// ---------------------------------------------
// Final metrics (for the combined 1 rules):
// -- Edit Location --
// Recall: 0.67, Precision: 0.29
// -- Node Change --
// Recall: 0.75, Precision: 0.30
// -- General --
// Functions fully changed: 1/8(12%)

/*
Functions where the patch did not apply:
 - vlc/prevFiles/prev_9e406b_c46a62_modules#stream_out#rtp.c:
*/
/*
Functions where the patch produced incorrect changes:
 - curl/prevFiles/prev_921bf1_b51e07_lib#url.c: setup_connection_internals
 - curl/prevFiles/prev_921bf1_b51e07_lib#url.c: SocketIsDead
 - curl/prevFiles/prev_921bf1_b51e07_lib#url.c: parseurlandfillconn
 - curl/prevFiles/prev_921bf1_b51e07_lib#url.c: Curl_setopt
 - curl/prevFiles/prev_921bf1_b51e07_lib#url.c: parse_remote_port
 - curl/prevFiles/prev_921bf1_b51e07_lib#url.c: ConnectionExists
*/

// ---------------------------------------------