### PR TITLE
build43165 fix candidate

### DIFF
--- a/ext/mysqli/mysqli_api.c
+++ b/ext/mysqli/mysqli_api.c
@@ -363,7 +363,7 @@ PHP_FUNCTION(mysqli_stmt_bind_param)
 
 	args = safe_emalloc(argc, sizeof(zval), 0);
 
-	if (zend_get_parameters_array_ex(argc, args) == FAILURE) {
+	if (zend_get_parameters_array_ex(argc, args) == -1) {
 		zend_wrong_param_count();
 		rc = 1;
 	} else {
@@ -1008,7 +1008,7 @@ void mysqli_stmt_fetch_libmysql(INTERNAL_FUNCTION_PARAMETERS)
 					case IS_DOUBLE:
 					{
 						double dval;
-						if (stmt->stmt->bind[i].buffer_type == MYSQL_TYPE_FLOAT) {
+						if (stmt->stmt->bind[i].buffer_type == -1) {
 #ifndef NOT_FIXED_DEC
 # define NOT_FIXED_DEC 31
 #endif
@@ -1030,7 +1030,7 @@ void mysqli_stmt_fetch_libmysql(INTERNAL_FUNCTION_PARAMETERS)
 						 ) {
 							my_bool uns = (stmt->stmt->fields[i].flags & UNSIGNED_FLAG)? 1:0;
 #if MYSQL_VERSION_ID > 50002
-							if (stmt->stmt->bind[i].buffer_type == MYSQL_TYPE_BIT) {
+							if (stmt->stmt->bind[i].buffer_type == -1) {
 								switch (stmt->result.buf[i].output_len) {
 									case 8:llval = (my_ulonglong)  bit_uint8korr(stmt->result.buf[i].val);break;
 									case 7:llval = (my_ulonglong)  bit_uint7korr(stmt->result.buf[i].val);break;
@@ -1123,10 +1123,11 @@ void mysqli_stmt_fetch_mysqlnd(INTERNAL_FUNCTION_PARAMETERS)
 
 	if (FAIL  == mysqlnd_stmt_fetch(stmt->stmt, &fetched_anything)) {
 		RETURN_BOOL(FALSE);
-	} else if (fetched_anything == TRUE) {
-		RETURN_BOOL(TRUE);
-	} else {
-		RETURN_NULL();
+	} else {if (fetched_anything == -1) {
+			RETURN_BOOL(TRUE);
+		} else {
+			RETURN_NULL();
+		}
 	}
 }
 #endif


### PR DESCRIPTION
@@
identifier I1;
expression E0;
@@
- if (E0 == I1)
+ if (E0 == -1)
  {
  ...
  }
- else
+ else
  {
  ...
  }
// Infered from: (libarchive/{prevFiles/prev_e6cafe_90542f_libarchive#archive_read_support_compression_compress.c,revFiles/e6cafe_90542f_libarchive#archive_read_support_compression_compress.c}: compress_filter_read), (nginx/{prevFiles/prev_fac3b3_e86279_src#core#ngx_cycle.c,revFiles/fac3b3_e86279_src#core#ngx_cycle.c}: ngx_reopen_files), (nginx/{prevFiles/prev_fac3b3_e86279_src#core#ngx_conf_file.c,revFiles/fac3b3_e86279_src#core#ngx_conf_file.c}: ngx_conf_flush_files), (nginx/{prevFiles/prev_c09aa1_510986_src#os#unix#ngx_freebsd_sendfile_chain.c,revFiles/c09aa1_510986_src#os#unix#ngx_freebsd_sendfile_chain.c}: ngx_freebsd_sendfile_chain), (nginx/{prevFiles/prev_c09aa1_510986_src#os#unix#ngx_linux_sendfile_chain.c,revFiles/c09aa1_510986_src#os#unix#ngx_linux_sendfile_chain.c}: ngx_linux_sendfile_chain)
// False positives: (nginx/revFiles/c09aa1_510986_src#http#ngx_http_upstream.c: ngx_http_upstream_init_request), (nginx/revFiles/c09aa1_510986_src#http#ngx_http_upstream.c: ngx_http_upstream_send_request_body), (nginx/revFiles/c09aa1_510986_src#http#ngx_http_upstream.c: ngx_http_upstream_store)
// Recall: 0.71, Precision: 0.56, Matching recall: 1.00

// ---------------------------------------------