### PR TITLE
build43165 fix candidate

### DIFF
--- a/ext/mysqli/mysqli_api.c
+++ b/ext/mysqli/mysqli_api.c
@@ -73,9 +73,12 @@ mysqli_escape_string_for_tx_name_in_comment(const char * const name)
 		const char * p_orig = name;
 		char * p_copy;
 		p_copy = ret = emalloc(strlen(name) + 1 + 2 + 2 + 1); /* space, open, close, NullS */
-		*p_copy++ = ' ';
-		*p_copy++ = '/';
-		*p_copy++ = '*';
+		*p_copy = ' ';
+		p_copy++;
+		*p_copy = '/';
+		p_copy++;
+		*p_copy = '*';
+		p_copy++;
 		while (1) {
 			register char v = *p_orig;
 			if (v == 0) {
@@ -89,16 +92,20 @@ mysqli_escape_string_for_tx_name_in_comment(const char * const name)
 				v == ' ' ||
 				v == '=')
 			{
-				*p_copy++ = v;
+				*p_copy = v;
+				p_copy++;
 			} else if (warned == FALSE) {
 				php_error_docref(NULL, E_WARNING, "Transaction name truncated. Must be only [0-9A-Za-z\\-_=]+");
 				warned = TRUE;
 			}
 			++p_orig;
 		}
-		*p_copy++ = '*';
-		*p_copy++ = '/';
-		*p_copy++ = 0;
+		*p_copy = '*';
+		p_copy++;
+		*p_copy = '/';
+		p_copy++;
+		*p_copy = 0;
+		p_copy++;
 	}
 	return ret;
 }


### PR DESCRIPTION
@@
expression E1, E0;
@@
- *E0++ = E1;
+ *E0 = E1;
+ E0++;
// Infered from: (php-src/{prevFiles/prev_82ba5b_81a7d5_ext#standard#crypt.c,revFiles/82ba5b_81a7d5_ext#standard#crypt.c}: php_to64)
// False positives: (FFmpeg/revFiles/49cf36_61e0e8_libavcodec#sanm.c: decode_6), (FFmpeg/revFiles/49cf36_61e0e8_libavcodec#sanm.c: decode_8), (FFmpeg/revFiles/49cf36_61e0e8_libavcodec#sanm.c: draw_glyph), (FFmpeg/revFiles/49cf36_61e0e8_libavcodec#sanm.c: fill_block), (FFmpeg/revFiles/49cf36_61e0e8_libavcodec#sanm.c: fill_frame)
// Recall: 1.00, Precision: 0.29, Matching recall: 1.00

// ---------------------------------------------
// Final metrics (for the combined 1 rules):
// -- Edit Location --
// Recall: 1.00, Precision: 0.29
// -- Node Change --
// Recall: 1.00, Precision: 0.29
// -- General --
// Functions fully changed: 2/7(28%)

/*
Functions where the patch produced incorrect changes:
 - FFmpeg/prevFiles/prev_49cf36_61e0e8_libavcodec#sanm.c: decode_6
 - FFmpeg/prevFiles/prev_49cf36_61e0e8_libavcodec#sanm.c: fill_frame
 - FFmpeg/prevFiles/prev_49cf36_61e0e8_libavcodec#sanm.c: fill_block
 - FFmpeg/prevFiles/prev_49cf36_61e0e8_libavcodec#sanm.c: draw_glyph
 - FFmpeg/prevFiles/prev_49cf36_61e0e8_libavcodec#sanm.c: decode_8
*/

// ---------------------------------------------