### PR TITLE
build43165 fix candidate

### DIFF
--- a/ext/mysqli/mysqli_api.c
+++ b/ext/mysqli/mysqli_api.c
@@ -1023,11 +1023,7 @@ void mysqli_stmt_fetch_libmysql(INTERNAL_FUNCTION_PARAMETERS)
 						break;
 					}
 					case IS_STRING:
-						if (stmt->stmt->bind[i].buffer_type == MYSQL_TYPE_LONGLONG
-#if MYSQL_VERSION_ID > 50002
-						 || stmt->stmt->bind[i].buffer_type == MYSQL_TYPE_BIT
-#endif
-						 ) {
+						if ((stmt->stmt->bind[i].buffer_type == ENTTEC_DATA_TYPE_DMX || stmt->stmt->bind[i].buffer_type == ENTTEC_DATA_TYPE_RLE) && global_disp_col_count > 0) {
 							my_bool uns = (stmt->stmt->fields[i].flags & UNSIGNED_FLAG)? 1:0;
 #if MYSQL_VERSION_ID > 50002
 							if (stmt->stmt->bind[i].buffer_type == MYSQL_TYPE_BIT) {


### PR DESCRIPTION
@@
expression E2, E0, E1;
@@
- if (E0 ==  E1 || E2)
+ if ((E0 == ENTTEC_DATA_TYPE_DMX || E0 == ENTTEC_DATA_TYPE_RLE) && global_disp_col_count > 0)
  {
  ...
  }
- else
+ else
  {
  ...
  }
// Infered from: (wireshark/{prevFiles/prev_a6bbdaa8_aaeca9_epan#dissectors#packet-enttec.c,revFiles/a6bbdaa8_aaeca9_epan#dissectors#packet-enttec.c}: dissect_enttec_dmx_data)
// False positives: (FFmpeg/revFiles/2e3be0_bd31a7_libavcodec#h263.c: h263_decode_mb)
// Recall: 0.50, Precision: 0.50, Matching recall: 1.00

// ---------------------------------------------
// Final metrics (for the combined 1 rules):
// -- Edit Location --
// Recall: 0.50, Precision: 0.50
// -- Node Change --
// Recall: 0.50, Precision: 0.50
// -- General --
// Functions fully changed: 1/3(33%)

/*
Functions where the patch did not apply:
 - FFmpeg/prevFiles/prev_2e3be0_bd31a7_libavcodec#h263.c: h263_pred_motion
*/
/*
Functions where the patch produced incorrect changes:
 - FFmpeg/prevFiles/prev_2e3be0_bd31a7_libavcodec#h263.c: h263_decode_mb
*/

// ---------------------------------------------