### PR TITLE
build43165 fix candidate

### DIFF
--- a/ext/mysqli/mysqli_api.c
+++ b/ext/mysqli/mysqli_api.c
@@ -1861,7 +1861,7 @@ PHP_FUNCTION(mysqli_prepare)
 			/* mysql_stmt_close() clears errors, so we have to store them temporarily */
 #if !defined(MYSQLI_USE_MYSQLND)
 			char  last_error[MYSQL_ERRMSG_SIZE];
-			char  sqlstate[SQLSTATE_LENGTH+1];
+			char sqlstate[1025];
 			unsigned int last_errno;
 
 			last_errno = stmt->stmt->last_errno;


### PR DESCRIPTION
@@
identifier I1;
expression E0;
@@
- char I1[E0 + 1];
+ char I1[1025];
// Infered from: (cmake/{prevFiles/prev_4772d6_0ae197_Source#kwsys#ProcessUNIX.c,revFiles/4772d6_0ae197_Source#kwsys#ProcessUNIX.c}: kwsysProcessKill)
// Recall: 0.50, Precision: 1.00, Matching recall: 1.00

// ---------------------------------------------
// Final metrics (for the combined 2 rules):
// -- Edit Location --
// Recall: 1.00, Precision: 1.00
// -- Node Change --
// Recall: 1.00, Precision: 1.00
// -- General --
// Functions fully changed: 2/2(100%)

// ---------------------------------------------