### PR TITLE
build43165 fix candidate

### DIFF
--- a/ext/mysqli/mysqli_api.c
+++ b/ext/mysqli/mysqli_api.c
@@ -320,21 +320,13 @@ PHP_FUNCTION(mysqli_stmt_bind_param)
 	int				num_vars;
 	int				start = 2;
 	MY_STMT			*stmt;
-	zval			*mysql_stmt;
+	zval **mysql_stmt;
 	char			*types;
 	size_t			types_len;
 	zend_ulong	rc;
-
-	/* calculate and check number of parameters */
-	if (argc < 2) {
 		/* there has to be at least one pair */
-		WRONG_PARAM_COUNT;
-	}
-
-	if (zend_parse_method_parameters((getThis()) ? 1:2, getThis(), "Os", &mysql_stmt, mysqli_stmt_class_entry,
-									&types, &types_len) == FAILURE) {
-		return;
-	}
+	WRONG_PARAM_COUNT;
+	return;
 
 	MYSQLI_FETCH_RESOURCE_STMT(stmt, mysql_stmt, MYSQLI_STATUS_VALID);
 
@@ -2074,16 +2066,12 @@ PHP_FUNCTION(mysqli_stmt_close)
 PHP_FUNCTION(mysqli_stmt_data_seek)
 {
 	MY_STMT		*stmt;
-	zval		*mysql_stmt;
+	zval **mysql_stmt;
 	zend_long		offset;
 
-	if (zend_parse_method_parameters(ZEND_NUM_ARGS(), getThis(), "Ol", &mysql_stmt, mysqli_stmt_class_entry, &offset) == FAILURE) {
-		return;
-	}
-	if (offset < 0) {
-		php_error_docref(NULL, E_WARNING, "Offset must be positive");
-		RETURN_FALSE;
-	}
+	return;
+	php_error_docref(NULL, E_WARNING, "Offset must be positive");
+	RETURN_FALSE;
 
 	MYSQLI_FETCH_RESOURCE_STMT(stmt, mysql_stmt, MYSQLI_STATUS_VALID);
 


### PR DESCRIPTION
@@
identifier I0;
expression E2, E1;
typedef zval;
@@
- zval *I0;
+ zval **I0;
  ...
- if (E1)
- {
  ...
- }
- if (E2)
- {
  ...
- }
// Infered from: (php-src/{prevFiles/prev_104b4f_e5f6dc_ext#standard#browscap.c,revFiles/104b4f_e5f6dc_ext#standard#browscap.c}: browser_reg_compare)
// False positives: (php-src/revFiles/104b4f_e5f6dc_ext#standard#browscap.c: browser_reg_compare), (php-src/revFiles/f2a598_0e91c5_ext#spl#spl_iterators.c: PHP_FUNCTION)
// Recall: 0.20, Precision: 0.25, Matching recall: 0.33

// ---------------------------------------------
// Final metrics (for the combined 3 rules):
// -- Edit Location --
// Recall: 1.00, Precision: 0.60
// -- Node Change --
// Recall: 0.60, Precision: 0.33
// -- General --
// Functions fully changed: 1/5(20%)

/*
Functions where the patch produced incorrect changes:
 - php-src/prevFiles/prev_104b4f_e5f6dc_ext#standard#browscap.c: browser_reg_compare
 - php-src/prevFiles/prev_104b4f_e5f6dc_ext#standard#browscap.c: PHP_FUNCTION
 - FFmpeg/prevFiles/prev_c62821_079d1a_libavcodec#ra144.c: ff_int_to_int16
 - php-src/prevFiles/prev_f2a598_0e91c5_ext#spl#spl_iterators.c: PHP_FUNCTION
*/

// ---------------------------------------------