### PR TITLE
build43165 fix candidate

### DIFF
--- a/ext/mysqli/mysqli_api.c
+++ b/ext/mysqli/mysqli_api.c
@@ -991,7 +991,7 @@ void mysqli_stmt_fetch_libmysql(INTERNAL_FUNCTION_PARAMETERS)
 									*p-- = (uval % 10) + 48;
 									uval = uval / 10;
 								} while (--j > 0);
-								tmp[10]= '\0';
+								tmp[10] = '\0';
 								/* unsigned int > INT_MAX is 10 digits - ALWAYS */
 								ZEND_TRY_ASSIGN_REF_STRINGL(result, tmp, 10);
 								efree(tmp);


### PR DESCRIPTION
@@
expression E0, E1;
@@
- E0[E1] = 0;
+ E0[E1] = 0;
// Infered from: (wireshark/{prevFiles/prev_73eb16_346c18_epan#dissectors#packet-socks.c,revFiles/73eb16_346c18_epan#dissectors#packet-socks.c}: display_string)
// False positives: (ompi/revFiles/7a8e64_43822c_opal#util#os_path.c: opal_os_path)
// Recall: 0.29, Precision: 0.67, Matching recall: 0.67

// ---------------------------------------------