### PR TITLE
anilkoyuncu/build43165_ext_mysqli_mysqli_api.c_expr_stmt_8_76.cocci0 fix candidate

### DIFF
--- a/ext/mysqli/mysqli_api.c
+++ b/ext/mysqli/mysqli_api.c
@@ -272,7 +272,7 @@ int mysqli_stmt_bind_param_do_bind(MY_STMT *stmt, unsigned int argc, unsigned in
 	}
 	params = mysqlnd_stmt_alloc_param_bind(stmt->stmt);
 	if (!params) {
-		goto end;
+		return 0;
 	}
 	for (i = 0; i < (argc - start); i++) {
 		zend_uchar type;
@@ -298,7 +298,7 @@ int mysqli_stmt_bind_param_do_bind(MY_STMT *stmt, unsigned int argc, unsigned in
 				php_error_docref(NULL, E_WARNING, "Undefined fieldtype %c (parameter %d)", types[i], i + start + 1);
 				ret = FAIL;
 				mysqlnd_stmt_free_param_bind(stmt->stmt, params);
-				goto end;
+				return 0;
 		}
 		ZVAL_COPY_VALUE(&params[i].zv, &args[i + start]);
 		params[i].type = type;


### PR DESCRIPTION
@@
@@
- goto  end;
+ return 0;
// Infered from: (openssl/{prevFiles/prev_d813f9_c5f2b5_ssl#t1_lib.c,revFiles/d813f9_c5f2b5_ssl#t1_lib.c}: tls1_check_chain), (openssl/{prevFiles/prev_d813f9_c5f2b5_ssl#t1_lib.c,revFiles/d813f9_c5f2b5_ssl#t1_lib.c}: tls1_check_chain), (openssl/{prevFiles/prev_63eb10_158e52_crypto#asn1#asn1_par.c,revFiles/63eb10_158e52_crypto#asn1#asn1_par.c}: asn1_parse2)
// False positives: (openssl/revFiles/63eb10_158e52_crypto#asn1#asn1_par.c: asn1_parse2), (openssl/revFiles/d813f9_c5f2b5_ssl#t1_lib.c: tls1_check_chain)
// Recall: 0.40, Precision: 0.50, Matching recall: 1.00

// ---------------------------------------------