### PR TITLE
build43165 fix candidate

### DIFF
--- a/ext/mysqli/mysqli_api.c
+++ b/ext/mysqli/mysqli_api.c
@@ -1247,7 +1247,7 @@ PHP_FUNCTION(mysqli_fetch_field_direct)
 		RETURN_FALSE;
 	}
 
-	if (!(field = mysql_fetch_field_direct(result,offset))) {
+	if (!(field = mysql_fetch_field_direct(result, offset))) {
 		RETURN_FALSE;
 	}
 


### PR DESCRIPTION
@@
expression E0;
@@
- if (E0 == NULL)
+ if (!E0)
  {
  ...
  }
// Infered from: (linux/{prevFiles/prev_4c42d97_6e3f3bb_drivers#staging#nvec#nvec.c,revFiles/4c42d97_6e3f3bb_drivers#staging#nvec#nvec.c}: tegra_nvec_probe)
// False positives: (FFmpeg/revFiles/88a849_00ffbd_libavformat#mpegts.c: ff_parse_mpeg2_descriptor), (linux/revFiles/1208f1_938db28_drivers#staging#vt6655#wpa.c: WPAb_Is_RSN), (linux/revFiles/28f5ca_4e7c85_drivers#staging#rtl8723au#hal#rtl8723a_hal_init.c: c2h_handler_8723a), (linux/revFiles/3408e9a_efeb257_drivers#staging#lustre#lustre#osc#osc_dev.c: osc_key_init), (linux/revFiles/3408e9a_efeb257_drivers#staging#lustre#lustre#osc#osc_dev.c: osc_session_init), (linux/revFiles/3408e9a_efeb257_drivers#staging#lustre#lustre#osc#osc_request.c: check_write_rcs), (linux/revFiles/3408e9a_efeb257_drivers#staging#lustre#lustre#osc#osc_request.c: osc_brw_fini_request), (linux/revFiles/3408e9a_efeb257_drivers#staging#lustre#lustre#osc#osc_request.c: osc_brw_prep_request), (linux/revFiles/3408e9a_efeb257_drivers#staging#lustre#lustre#osc#osc_request.c: osc_build_rpc), (linux/revFiles/3408e9a_efeb257_drivers#staging#lustre#lustre#osc#osc_request.c: osc_destroy), (linux/revFiles/3408e9a_efeb257_drivers#staging#lustre#lustre#osc#osc_request.c: osc_disconnect), (linux/revFiles/3408e9a_efeb257_drivers#staging#lustre#lustre#osc#osc_request.c: osc_enqueue_base), (linux/revFiles/3408e9a_efeb257_drivers#staging#lustre#lustre#osc#osc_request.c: osc_get_info), (linux/revFiles/3408e9a_efeb257_drivers#staging#lustre#lustre#osc#osc_request.c: osc_getattr), (linux/revFiles/3408e9a_efeb257_drivers#staging#lustre#lustre#osc#osc_request.c: osc_getattr_async), (linux/revFiles/3408e9a_efeb257_drivers#staging#lustre#lustre#osc#osc_request.c: osc_packmd), (linux/revFiles/3408e9a_efeb257_drivers#staging#lustre#lustre#osc#osc_request.c: osc_punch_base), (linux/revFiles/3408e9a_efeb257_drivers#staging#lustre#lustre#osc#osc_request.c: osc_real_create), (linux/revFiles/3408e9a_efeb257_drivers#staging#lustre#lustre#osc#osc_request.c: osc_resource_get_unused), (linux/revFiles/3408e9a_efeb257_drivers#staging#lustre#lustre#osc#osc_request.c: osc_set_info_async), (linux/revFiles/3408e9a_efeb257_drivers#staging#lustre#lustre#osc#osc_request.c: osc_set_lock_data_with_check), (linux/revFiles/3408e9a_efeb257_drivers#staging#lustre#lustre#osc#osc_request.c: osc_setattr), (linux/revFiles/3408e9a_efeb257_drivers#staging#lustre#lustre#osc#osc_request.c: osc_setattr_async_base), (linux/revFiles/3408e9a_efeb257_drivers#staging#lustre#lustre#osc#osc_request.c: osc_setattr_interpret), (linux/revFiles/3408e9a_efeb257_drivers#staging#lustre#lustre#osc#osc_request.c: osc_statfs), (linux/revFiles/3408e9a_efeb257_drivers#staging#lustre#lustre#osc#osc_request.c: osc_statfs_async), (linux/revFiles/3408e9a_efeb257_drivers#staging#lustre#lustre#osc#osc_request.c: osc_statfs_interpret), (linux/revFiles/3408e9a_efeb257_drivers#staging#lustre#lustre#osc#osc_request.c: osc_sync_base), (linux/revFiles/3408e9a_efeb257_drivers#staging#lustre#lustre#osc#osc_request.c: osc_sync_interpret), (linux/revFiles/3408e9a_efeb257_drivers#staging#lustre#lustre#osc#osc_request.c: osc_unpackmd), (linux/revFiles/36a86f_76e4290_drivers#staging#lustre#lustre#lov#lov_dev.c: lov_device_fini), (linux/revFiles/36a86f_76e4290_drivers#staging#lustre#lustre#lov#lov_dev.c: lov_device_init), (linux/revFiles/36a86f_76e4290_drivers#staging#lustre#lustre#lov#lov_dev.c: lov_emerg_alloc), (linux/revFiles/36a86f_76e4290_drivers#staging#lustre#lustre#lov#lov_dev.c: lov_session_key_init), (linux/revFiles/36a86f_76e4290_drivers#staging#lustre#lustre#lov#lov_io.c: lov_io_submit), (linux/revFiles/36a86f_76e4290_drivers#staging#lustre#lustre#lov#lov_obd.c: lov_add_target), (linux/revFiles/36a86f_76e4290_drivers#staging#lustre#lustre#lov#lov_obd.c: lov_create), (linux/revFiles/36a86f_76e4290_drivers#staging#lustre#lustre#lov#lov_obd.c: lov_fiemap), (linux/revFiles/36a86f_76e4290_drivers#staging#lustre#lustre#lov#lov_obd.c: lov_init), (linux/revFiles/36a86f_76e4290_drivers#staging#lustre#lustre#lov#lov_obd.c: lov_iocontrol), (linux/revFiles/36a86f_76e4290_drivers#staging#lustre#lustre#lov#lov_obd.c: lov_recreate), (linux/revFiles/36a86f_76e4290_drivers#staging#lustre#lustre#lov#lov_obd.c: lov_set_info_async), (linux/revFiles/36a86f_76e4290_drivers#staging#lustre#lustre#lov#lov_obd.c: lov_statfs), (linux/revFiles/36a86f_76e4290_drivers#staging#lustre#lustre#lov#lov_pool.c: lov_find_pool), (linux/revFiles/36a86f_76e4290_drivers#staging#lustre#lustre#lov#lov_pool.c: lov_ost_pool_extend), (linux/revFiles/36a86f_76e4290_drivers#staging#lustre#lustre#lov#lov_pool.c: lov_ost_pool_init), (linux/revFiles/36a86f_76e4290_drivers#staging#lustre#lustre#lov#lov_pool.c: lov_pool_add), (linux/revFiles/36a86f_76e4290_drivers#staging#lustre#lustre#lov#lov_pool.c: lov_pool_del), (linux/revFiles/36a86f_76e4290_drivers#staging#lustre#lustre#lov#lov_pool.c: lov_pool_remove), (linux/revFiles/485640_c829be81_drivers#staging#lustre#lustre#obdclass#class_obd.c: class_handle_ioctl), (linux/revFiles/485640_c829be81_drivers#staging#lustre#lustre#obdclass#class_obd.c: init_obdclass), (linux/revFiles/485640_c829be81_drivers#staging#lustre#lustre#obdclass#lprocfs_status.c: lprocfs_alloc_md_stats), (linux/revFiles/485640_c829be81_drivers#staging#lustre#lustre#obdclass#lprocfs_status.c: lprocfs_alloc_obd_stats), (linux/revFiles/485640_c829be81_drivers#staging#lustre#lustre#obdclass#lprocfs_status.c: lprocfs_alloc_stats), (linux/revFiles/485640_c829be81_drivers#staging#lustre#lustre#obdclass#lprocfs_status.c: lprocfs_clear_stats), (linux/revFiles/485640_c829be81_drivers#staging#lustre#lustre#obdclass#lprocfs_status.c: lprocfs_counter_init), (linux/revFiles/485640_c829be81_drivers#staging#lustre#lustre#obdclass#lprocfs_status.c: lprocfs_find_named_value), (linux/revFiles/485640_c829be81_drivers#staging#lustre#lustre#obdclass#lprocfs_status.c: lprocfs_rd_import), (linux/revFiles/485640_c829be81_drivers#staging#lustre#lustre#obdclass#lprocfs_status.c: lprocfs_stats_collect), (linux/revFiles/4bb0142_38272d2_drivers#staging#rtl8192e#rtl819x_TSProc.c: MakeTSEntry), (linux/revFiles/4c42d97_6e3f3bb_drivers#staging#nvec#nvec.c: nvec_write_async), (linux/revFiles/53db33_85b45e_drivers#staging#media#zoran#zoran_driver.c: jpg_fbuffer_alloc), (linux/revFiles/53db33_85b45e_drivers#staging#media#zoran#zoran_driver.c: setup_window), (linux/revFiles/597851_3408e9a_drivers#staging#lustre#lustre#ptlrpc#client.c: __ptlrpc_free_req), (linux/revFiles/597851_3408e9a_drivers#staging#lustre#lustre#ptlrpc#client.c: __ptlrpc_req_finished), (linux/revFiles/597851_3408e9a_drivers#staging#lustre#lustre#ptlrpc#client.c: ptlrpc_expire_one_request), (linux/revFiles/597851_3408e9a_drivers#staging#lustre#lustre#ptlrpc#client.c: ptlrpc_prep_bulk_imp), (linux/revFiles/597851_3408e9a_drivers#staging#lustre#lustre#ptlrpc#client.c: ptlrpc_queue_wait), (linux/revFiles/597851_3408e9a_drivers#staging#lustre#lustre#ptlrpc#client.c: ptlrpc_request_alloc_internal), (linux/revFiles/597851_3408e9a_drivers#staging#lustre#lustre#ptlrpc#client.c: ptlrpcd_alloc_work), (linux/revFiles/597851_3408e9a_drivers#staging#lustre#lustre#ptlrpc#nrs.c: nrs_policy_ctl), (linux/revFiles/597851_3408e9a_drivers#staging#lustre#lustre#ptlrpc#nrs.c: nrs_policy_register), (linux/revFiles/597851_3408e9a_drivers#staging#lustre#lustre#ptlrpc#nrs.c: nrs_policy_start_locked), (linux/revFiles/597851_3408e9a_drivers#staging#lustre#lustre#ptlrpc#nrs.c: nrs_policy_stop_primary), (linux/revFiles/597851_3408e9a_drivers#staging#lustre#lustre#ptlrpc#nrs.c: nrs_policy_unregister), (linux/revFiles/597851_3408e9a_drivers#staging#lustre#lustre#ptlrpc#nrs.c: nrs_request_enqueue), (linux/revFiles/597851_3408e9a_drivers#staging#lustre#lustre#ptlrpc#nrs.c: nrs_resource_get_safe), (linux/revFiles/597851_3408e9a_drivers#staging#lustre#lustre#ptlrpc#nrs.c: nrs_resource_put_safe), (linux/revFiles/597851_3408e9a_drivers#staging#lustre#lustre#ptlrpc#nrs.c: nrs_svcpt_setup_locked), (linux/revFiles/597851_3408e9a_drivers#staging#lustre#lustre#ptlrpc#nrs.c: ptlrpc_nrs_policy_unregister), (linux/revFiles/597851_3408e9a_drivers#staging#lustre#lustre#ptlrpc#ptlrpcd.c: ptlrpcd_check), (linux/revFiles/597851_3408e9a_drivers#staging#lustre#lustre#ptlrpc#ptlrpcd.c: ptlrpcd_start), (linux/revFiles/597851_3408e9a_drivers#staging#lustre#lustre#ptlrpc#sec_config.c: __sptlrpc_process_config), (linux/revFiles/597851_3408e9a_drivers#staging#lustre#lustre#ptlrpc#sec_config.c: sptlrpc_conf_choose_flavor), (linux/revFiles/597851_3408e9a_drivers#staging#lustre#lustre#ptlrpc#sec_config.c: sptlrpc_parse_flavor), (linux/revFiles/597851_3408e9a_drivers#staging#lustre#lustre#ptlrpc#sec_config.c: sptlrpc_parse_rule), (linux/revFiles/597851_3408e9a_drivers#staging#lustre#lustre#ptlrpc#sec_config.c: sptlrpc_rule_set_expand), (linux/revFiles/597851_3408e9a_drivers#staging#lustre#lustre#ptlrpc#sec_plain.c: plain_accept), (linux/revFiles/597851_3408e9a_drivers#staging#lustre#lustre#ptlrpc#sec_plain.c: plain_alloc_rs), (linux/revFiles/597851_3408e9a_drivers#staging#lustre#lustre#ptlrpc#sec_plain.c: plain_create_sec), (linux/revFiles/597851_3408e9a_drivers#staging#lustre#lustre#ptlrpc#sec_plain.c: plain_ctx_verify), (linux/revFiles/597851_3408e9a_drivers#staging#lustre#lustre#ptlrpc#sec_plain.c: plain_enlarge_reqbuf), (linux/revFiles/597851_3408e9a_drivers#staging#lustre#lustre#ptlrpc#sec_plain.c: plain_unpack_bsd), (linux/revFiles/597851_3408e9a_drivers#staging#lustre#lustre#ptlrpc#service.c: ptlrpc_alloc_rqbd), (linux/revFiles/597851_3408e9a_drivers#staging#lustre#lustre#ptlrpc#service.c: ptlrpc_at_send_early_reply), (linux/revFiles/597851_3408e9a_drivers#staging#lustre#lustre#ptlrpc#service.c: ptlrpc_grow_req_bufs), (linux/revFiles/597851_3408e9a_drivers#staging#lustre#lustre#ptlrpc#service.c: ptlrpc_hr_fini), (linux/revFiles/597851_3408e9a_drivers#staging#lustre#lustre#ptlrpc#service.c: ptlrpc_hr_init), (linux/revFiles/597851_3408e9a_drivers#staging#lustre#lustre#ptlrpc#service.c: ptlrpc_register_service), (linux/revFiles/597851_3408e9a_drivers#staging#lustre#lustre#ptlrpc#service.c: ptlrpc_server_handle_request), (linux/revFiles/597851_3408e9a_drivers#staging#lustre#lustre#ptlrpc#service.c: ptlrpc_service_free), (linux/revFiles/597851_3408e9a_drivers#staging#lustre#lustre#ptlrpc#service.c: ptlrpc_service_health_check), (linux/revFiles/597851_3408e9a_drivers#staging#lustre#lustre#ptlrpc#service.c: ptlrpc_service_part_init), (linux/revFiles/597851_3408e9a_drivers#staging#lustre#lustre#ptlrpc#service.c: ptlrpc_service_purge_all), (linux/revFiles/597851_3408e9a_drivers#staging#lustre#lustre#ptlrpc#service.c: ptlrpc_service_unlink_rqbd), (linux/revFiles/597851_3408e9a_drivers#staging#lustre#lustre#ptlrpc#service.c: ptlrpc_start_thread), (linux/revFiles/597851_3408e9a_drivers#staging#lustre#lustre#ptlrpc#service.c: ptlrpc_stop_hr_threads), (linux/revFiles/597851_3408e9a_drivers#staging#lustre#lustre#ptlrpc#service.c: ptlrpc_svcpt_health_check), (linux/revFiles/61645cc_f705a2d_drivers#staging#rtl8192u#ieee80211#ieee80211_rx.c: ieee80211_frag_cache_get), (linux/revFiles/61645cc_f705a2d_drivers#staging#rtl8192u#ieee80211#ieee80211_rx.c: ieee80211_frag_cache_invalidate), (linux/revFiles/61645cc_f705a2d_drivers#staging#rtl8192u#ieee80211#ieee80211_rx.c: ieee80211_read_qos_info_element), (linux/revFiles/61645cc_f705a2d_drivers#staging#rtl8192u#r8192U_core.c: rtl8192_usb_probe), (linux/revFiles/6633282_c671dfd_drivers#staging#uwb#rsv.c: uwb_rsv_setup), (linux/revFiles/6c7c655_6fdb302_drivers#staging#lustre#lustre#fid#fid_request.c: seq_client_alloc_super), (linux/revFiles/6c7c655_6fdb302_drivers#staging#lustre#lustre#fid#fid_request.c: seq_client_rpc), (linux/revFiles/6e3f3bb_87e3db_drivers#staging#goldfish#goldfish_audio.c: goldfish_audio_probe), (linux/revFiles/76e4290_94e677_drivers#staging#lustre#lustre#lmv#lmv_intent.c: lmv_intent_lookup), (linux/revFiles/76e4290_94e677_drivers#staging#lustre#lustre#lmv#lmv_intent.c: lmv_intent_open), (linux/revFiles/76e4290_94e677_drivers#staging#lustre#lustre#lmv#lmv_intent.c: lmv_intent_remote), (linux/revFiles/812f20_6c7c655_drivers#staging#lustre#lustre#fld#fld_cache.c: fld_cache_insert_nolock), (linux/revFiles/812f20_6c7c655_drivers#staging#lustre#lustre#fld#fld_request.c: fld_client_rpc), (linux/revFiles/87e3db_9d877f_drivers#staging#gdm72xx#gdm_wimax.c: gdm_wimax_header), (linux/revFiles/87e3db_9d877f_drivers#staging#gdm72xx#gdm_wimax.c: gdm_wimax_ioctl_set_data), (linux/revFiles/9155c92_bb106dc_drivers#staging#rtl8712#recv_linux.c: r8712_recv_indicatepkt), (linux/revFiles/9155c92_bb106dc_drivers#staging#rtl8712#rtl871x_io.c: _init_intf_hdl), (linux/revFiles/9155c92_bb106dc_drivers#staging#rtl8712#rtl871x_io.c: r8712_alloc_io_queue), (linux/revFiles/9155c92_bb106dc_drivers#staging#rtl8712#rtl871x_sta_mgt.c: r8712_free_stainfo), (linux/revFiles/9155c92_bb106dc_drivers#staging#rtl8712#rtl871x_sta_mgt.c: r8712_get_stainfo), (linux/revFiles/9155c92_bb106dc_drivers#staging#rtl8712#rtl871x_xmit.c: _free_xmit_priv), (linux/revFiles/9155c92_bb106dc_drivers#staging#rtl8712#rtl871x_xmit.c: r8712_free_xmitbuf), (linux/revFiles/9155c92_bb106dc_drivers#staging#rtl8712#rtl871x_xmit.c: r8712_free_xmitframe), (linux/revFiles/9155c92_bb106dc_drivers#staging#rtl8712#rtl871x_xmit.c: r8712_free_xmitframe_ex), (linux/revFiles/9155c92_bb106dc_drivers#staging#rtl8712#rtl871x_xmit.c: r8712_update_attrib), (linux/revFiles/9155c92_bb106dc_drivers#staging#rtl8712#rtl871x_xmit.c: r8712_xmit_classifier), (linux/revFiles/9155c92_bb106dc_drivers#staging#rtl8712#rtl871x_xmit.c: r8712_xmitframe_coalesce), (linux/revFiles/94e677_c38ce3_drivers#staging#lustre#lustre#ldlm#ldlm_lock.c: __ldlm_handle2lock), (linux/revFiles/94e677_c38ce3_drivers#staging#lustre#lustre#ldlm#ldlm_lock.c: _ldlm_lock_debug), (linux/revFiles/94e677_c38ce3_drivers#staging#lustre#lustre#ldlm#ldlm_lock.c: ldlm_lock_change_resource), (linux/revFiles/94e677_c38ce3_drivers#staging#lustre#lustre#ldlm#ldlm_lock.c: ldlm_lock_convert), (linux/revFiles/94e677_c38ce3_drivers#staging#lustre#lustre#ldlm#ldlm_lock.c: ldlm_lock_create), (linux/revFiles/94e677_c38ce3_drivers#staging#lustre#lustre#ldlm#ldlm_lock.c: ldlm_lock_dump_handle), (linux/revFiles/94e677_c38ce3_drivers#staging#lustre#lustre#ldlm#ldlm_lock.c: ldlm_lock_enqueue), (linux/revFiles/94e677_c38ce3_drivers#staging#lustre#lustre#ldlm#ldlm_lock.c: ldlm_lock_match), (linux/revFiles/94e677_c38ce3_drivers#staging#lustre#lustre#ldlm#ldlm_lock.c: ldlm_lock_new), (linux/revFiles/94e677_c38ce3_drivers#staging#lustre#lustre#ldlm#ldlm_lock.c: ldlm_lock_set_data), (linux/revFiles/94e677_c38ce3_drivers#staging#lustre#lustre#ldlm#ldlm_lock.c: ldlm_run_ast_work), (linux/revFiles/94e677_c38ce3_drivers#staging#lustre#lustre#ldlm#ldlm_pool.c: ldlm_pools_count), (linux/revFiles/94e677_c38ce3_drivers#staging#lustre#lustre#ldlm#ldlm_pool.c: ldlm_pools_recalc), (linux/revFiles/94e677_c38ce3_drivers#staging#lustre#lustre#ldlm#ldlm_pool.c: ldlm_pools_thread_stop), (linux/revFiles/9d877f_93275c_drivers#staging#gdm724x#gdm_lte.c: gdm_lte_receive_pkt), (linux/revFiles/9d877f_93275c_drivers#staging#gdm724x#gdm_lte.c: unregister_lte_device), (linux/revFiles/a0886f_2a7089d_drivers#staging#rtl8192u#ieee80211#rtl819x_TSProc.c: MakeTSEntry), (linux/revFiles/bbae61_1f70971_drivers#staging#media#atomisp#pci#atomisp2#css2400#sh_css_param_shading.c: ia_css_shading_table_alloc), (linux/revFiles/bbae61_1f70971_drivers#staging#media#atomisp#pci#atomisp2#css2400#sh_css_param_shading.c: ia_css_shading_table_free), (linux/revFiles/bbae61_1f70971_drivers#staging#media#atomisp#pci#atomisp2#css2400#sh_css_param_shading.c: prepare_shading_table), (linux/revFiles/bbae61_1f70971_drivers#staging#media#atomisp#pci#atomisp2#css2400#sh_css_param_shading.c: sh_css_params_shading_id_table_generate), (linux/revFiles/c38ce3_812f20_drivers#staging#lustre#lustre#lclient#lcommon_cl.c: ccc_key_init), (linux/revFiles/c38ce3_812f20_drivers#staging#lustre#lustre#lclient#lcommon_cl.c: ccc_session_key_init), (linux/revFiles/c829be81_bb144d0_drivers#staging#lustre#lustre#mgc#mgc_request.c: config_log_add), (linux/revFiles/c829be81_bb144d0_drivers#staging#lustre#lustre#mgc#mgc_request.c: config_log_end), (linux/revFiles/c829be81_bb144d0_drivers#staging#lustre#lustre#mgc#mgc_request.c: lprocfs_mgc_rd_ir_state), (linux/revFiles/c829be81_bb144d0_drivers#staging#lustre#lustre#mgc#mgc_request.c: mgc_apply_recover_logs), (linux/revFiles/c829be81_bb144d0_drivers#staging#lustre#lustre#mgc#mgc_request.c: mgc_enqueue), (linux/revFiles/c829be81_bb144d0_drivers#staging#lustre#lustre#mgc#mgc_request.c: mgc_process_config), (linux/revFiles/c829be81_bb144d0_drivers#staging#lustre#lustre#mgc#mgc_request.c: mgc_process_recover_log), (linux/revFiles/c829be81_bb144d0_drivers#staging#lustre#lustre#mgc#mgc_request.c: mgc_target_register), (linux/revFiles/ce9d85_0f3083_drivers#usb#serial#mos7840.c: mos7840_break), (linux/revFiles/ce9d85_0f3083_drivers#usb#serial#mos7840.c: mos7840_change_port_settings), (linux/revFiles/ce9d85_0f3083_drivers#usb#serial#mos7840.c: mos7840_chars_in_buffer), (linux/revFiles/ce9d85_0f3083_drivers#usb#serial#mos7840.c: mos7840_get_serial_info), (linux/revFiles/ce9d85_0f3083_drivers#usb#serial#mos7840.c: mos7840_ioctl), (linux/revFiles/ce9d85_0f3083_drivers#usb#serial#mos7840.c: mos7840_open), (linux/revFiles/ce9d85_0f3083_drivers#usb#serial#mos7840.c: mos7840_send_cmd_write_baud_rate), (linux/revFiles/ce9d85_0f3083_drivers#usb#serial#mos7840.c: mos7840_set_termios), (linux/revFiles/ce9d85_0f3083_drivers#usb#serial#mos7840.c: mos7840_throttle), (linux/revFiles/ce9d85_0f3083_drivers#usb#serial#mos7840.c: mos7840_tiocmget), (linux/revFiles/ce9d85_0f3083_drivers#usb#serial#mos7840.c: mos7840_tiocmset), (linux/revFiles/ce9d85_0f3083_drivers#usb#serial#mos7840.c: mos7840_unthrottle), (linux/revFiles/ce9d85_0f3083_drivers#usb#serial#mos7840.c: mos7840_write), (linux/revFiles/ce9d85_0f3083_drivers#usb#serial#mos7840.c: mos7840_write_room), (vlc/revFiles/534232_9ce573_modules#access#vcd#cdrom.c: OpenVCDImage), (vlc/revFiles/534232_9ce573_modules#access#vcd#cdrom.c: ioctl_GetTracksMap), (vlc/revFiles/534232_9ce573_modules#access#vcd#cdrom.c: ioctl_Open)
// Recall: 0.81, Precision: 0.26, Matching recall: 0.98

// ---------------------------------------------